### PR TITLE
fix: keep scroll position after deleting a set

### DIFF
--- a/src/components/workout/confirm_dialog.tsx
+++ b/src/components/workout/confirm_dialog.tsx
@@ -40,6 +40,7 @@ export function ConfirmDialog({
 }) {
   return (
     <Dialog
+      modal={false}
       open={open}
       onOpenChange={(o) => (onOpenChange ? onOpenChange(o) : !o && onCancel())}
     >
@@ -53,10 +54,16 @@ export function ConfirmDialog({
           ) : null}
         </DialogHeader>
         <DialogFooter className="bg-muted/20 flex flex-row justify-end gap-3 border-t p-4">
-          <Button variant="outline" onClick={onCancel} className="px-6">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            className="px-6"
+          >
             {cancelLabel}
           </Button>
           <Button
+            type="button"
             variant={confirmVariant}
             onClick={onConfirm}
             className="px-6"


### PR DESCRIPTION
## Summary
- prevent ConfirmDialog buttons from submitting a form and scrolling page to top
- disable dialog focus trap by setting modal=false so page doesn't jump after a delete

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd871f80083209e0d4ed4c91069d4