### PR TITLE
fix: keep scroll position after deleting a set

### DIFF
--- a/src/components/workout/confirm_dialog.tsx
+++ b/src/components/workout/confirm_dialog.tsx
@@ -53,10 +53,16 @@ export function ConfirmDialog({
           ) : null}
         </DialogHeader>
         <DialogFooter className="bg-muted/20 flex flex-row justify-end gap-3 border-t p-4">
-          <Button variant="outline" onClick={onCancel} className="px-6">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            className="px-6"
+          >
             {cancelLabel}
           </Button>
           <Button
+            type="button"
             variant={confirmVariant}
             onClick={onConfirm}
             className="px-6"

--- a/src/components/workout/exercise_notes.tsx
+++ b/src/components/workout/exercise_notes.tsx
@@ -110,7 +110,9 @@ export function ExerciseNotes({
                 <div className="flex w-full items-center gap-2">
                   {editingIndex === i ? (
                     <Input
-                      ref={(el) => (inputRefs.current[i] = el)}
+                      ref={(el) => {
+                        inputRefs.current[i] = el;
+                      }}
                       className="border-input bg-background placeholder:text-muted-foreground/70 h-7 w-full flex-1 rounded border px-2 text-[11px] italic shadow-none focus-visible:ring-1"
                       value={n.text}
                       onChange={(e) => onUpdate(i, e.target.value)}

--- a/src/components/workout/finish_dialog.tsx
+++ b/src/components/workout/finish_dialog.tsx
@@ -37,7 +37,7 @@ export function FinishDialog({
     name: string;
     startedAt: Date;
     completedAt: Date;
-    exercises: Array<{ sets: Array<{}> }>;
+    exercises: Array<{ sets: Array<Record<string, unknown>> }>;
   };
   date: string;
   startTime: string;


### PR DESCRIPTION
## Summary
- prevent ConfirmDialog buttons from submitting a form and scrolling page to top
- keep ConfirmDialog modal to preserve focus handling
- avoid returning DOM nodes from exercise note input ref
- replace empty object type in finish dialog

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bd871f80083209e0d4ed4c91069d4