### PR TITLE
Enable plus/minus keys for reps input

### DIFF
--- a/src/lib/workoutLogic.ts
+++ b/src/lib/workoutLogic.ts
@@ -635,14 +635,23 @@ export const workoutReducer = (state: Workout, action: Action): Workout => {
 
     case "PLUS_MINUS": {
       const activeSet = getActiveSet();
-      // Now only applies to weight field, and only increments/decrements
-      if (!activeSet || activeField.field !== "weight") return state;
+      if (!activeSet || activeField.field == null) return state;
 
-      const currentVal = parseFloat(state.inputValue) || 0;
-      const sign = action.sign;
-      const step = sign * WEIGHT_STEP;
-      const newVal = String(roundToStep(currentVal + step));
-      return applyInput(state, newVal, true);
+      if (activeField.field === "weight") {
+        const currentVal = parseFloat(state.inputValue) || 0;
+        const step = action.sign * WEIGHT_STEP;
+        const newVal = String(roundToStep(currentVal + step));
+        return applyInput(state, newVal, true);
+      }
+
+      if (activeField.field === "reps") {
+        const currentVal = parseInt(state.inputValue, 10) || 0;
+        const step = action.sign;
+        const newVal = String(Math.max(currentVal + step, 0));
+        return applyInput(state, newVal, true);
+      }
+
+      return state;
     }
 
     case "TOGGLE_SIGN": {

--- a/test/workoutLogic.test.ts
+++ b/test/workoutLogic.test.ts
@@ -2,7 +2,9 @@ import {
   nextProgression,
   estimateSet,
   initialiseExercises,
+  workoutReducer,
 } from "@/lib/workoutLogic";
+import type { Workout } from "@/lib/workoutLogic";
 
 describe("progression helpers", () => {
   it("cycles 12→8 and bumps weight", () => {
@@ -18,5 +20,45 @@ describe("progression helpers", () => {
     const est = estimateSet(ex.sets, 0, ex);
     expect(est.weight).toBe(45);
     expect(est.reps).toBe(15);
+  });
+});
+
+describe("PLUS_MINUS reducer", () => {
+  const baseState = (): Workout => ({
+    currentExerciseIndex: 0,
+    exercises: initialiseExercises([
+      { name: "Bench", sets: [{ weight: null, reps: 5 }] },
+    ]),
+    activeField: { exerciseIndex: 0, setIndex: 0, field: "reps" },
+    inputValue: "5",
+    isFirstInteraction: false,
+    notes: [],
+    startTime: 0,
+    name: "Workout",
+    isInProgress: true,
+  });
+
+  it("increments and decrements reps", () => {
+    const state = baseState();
+    const inc = workoutReducer(state, { type: "PLUS_MINUS", sign: 1 });
+    expect(inc.inputValue).toBe("6");
+    expect(inc.exercises[0].sets[0].reps).toBe(6);
+
+    const dec = workoutReducer(inc, { type: "PLUS_MINUS", sign: -1 });
+    expect(dec.inputValue).toBe("5");
+    expect(dec.exercises[0].sets[0].reps).toBe(5);
+  });
+
+  it("does not decrement reps below zero", () => {
+    const state: Workout = {
+      ...baseState(),
+      inputValue: "0",
+      exercises: initialiseExercises([
+        { name: "Bench", sets: [{ weight: null, reps: 0 }] },
+      ]),
+    };
+    const dec = workoutReducer(state, { type: "PLUS_MINUS", sign: -1 });
+    expect(dec.inputValue).toBe("0");
+    expect(dec.exercises[0].sets[0].reps).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- support incrementing and decrementing reps via plus/minus keys
- add reducer tests for reps adjustment and bounds

## Testing
- `npm test`
- `npm run lint` *(fails: The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.)*


------
https://chatgpt.com/codex/tasks/task_e_68a8fd9ff6ac8320a379852df6ff8cd8