### PR TITLE
Fix plate calculator select layering

### DIFF
--- a/apps/web/src/components/workout-reference/weight_helper_dialog.tsx
+++ b/apps/web/src/components/workout-reference/weight_helper_dialog.tsx
@@ -443,7 +443,7 @@ function PlateHelper({ defaultWeight }: { defaultWeight: number }) {
                   {getStartingWeightLabel(startingWeightValue)}
                 </span>
               </SelectTrigger>
-              <SelectContent className="rounded-[4px] border-[#d7cfbc] bg-[#fdfcf8] font-mono text-[#17150f] shadow-none">
+              <SelectContent className="!z-[80] rounded-[4px] border-[#d7cfbc] bg-[#fdfcf8] font-mono text-[#17150f] shadow-none">
                 {BARS.map((bar) => (
                   <SelectItem
                     key={bar.value}


### PR DESCRIPTION
## Summary
- Raise the plate calculator starting-weight select menu above the stacked dialog layer.
- Add UserExercise plate defaults for starting weight and load mode.
- Thread those defaults into the workout set keyboard, increase-weight helper, plate calculator, and exercise header display.

## Validation
- `npm run typecheck -w @lift-prog/web`
- `npm run test -w @lift-prog/web -- exerciseRouter.test.ts`
- Browser smoke on `http://127.0.0.1:3011/workout-reference`: opened set editor, opened plate dialog, confirmed starting-weight options are visible above the stacked dialog layer.

## Migration
- Added `prisma/migrations/20260619143000_user_exercise_plate_defaults/migration.sql`.
- Prod Turso migration has not been applied yet; it needs explicit approval before running the two `ALTER TABLE UserExercise` statements.