### PR TITLE
Add exercise plate settings editor

### DIFF
--- a/apps/web/src/components/workout-reference/exercise_reference_frame.tsx
+++ b/apps/web/src/components/workout-reference/exercise_reference_frame.tsx
@@ -23,6 +23,7 @@ export function ExerciseReferenceShell({
 export function ExerciseReferenceHeader({
   name,
   note,
+  plateSettingsText,
   workoutExerciseNote,
   hasHistory,
   historyVisible,
@@ -32,6 +33,7 @@ export function ExerciseReferenceHeader({
 }: {
   name: string;
   note: string;
+  plateSettingsText?: string;
   workoutExerciseNote: string;
   hasHistory: boolean;
   historyVisible: boolean;
@@ -77,6 +79,11 @@ export function ExerciseReferenceHeader({
             <span>{note}</span>
           </NoteBadge>
         </button>
+      ) : null}
+      {plateSettingsText?.trim() ? (
+        <div className="text-[11px] leading-3 text-[#716b5d]">
+          {plateSettingsText}
+        </div>
       ) : null}
     </div>
   );

--- a/apps/web/src/components/workout-reference/previous-workout-exercise.tsx
+++ b/apps/web/src/components/workout-reference/previous-workout-exercise.tsx
@@ -20,7 +20,10 @@ import type {
   PreviousExercise,
   SetChangeOptions,
 } from "@/components/workout-reference/workout_reference_types";
-import type { PlateSettings } from "@/components/workout-reference/weight_helper_dialog";
+import {
+  PlateSettingsControls,
+  type PlateSettings,
+} from "@/components/workout-reference/weight_helper_dialog";
 import type { PlateMode } from "@/lib/weight-helper";
 
 type PreviousWorkoutExerciseProps = {
@@ -112,7 +115,15 @@ export function PreviousWorkoutExercise({
         onOpenChange={setUserExerciseNoteEditorOpen}
         onSave={(note) => onExerciseNoteChange?.(note)}
         onDelete={() => onExerciseNoteChange?.("")}
-      />
+      >
+        {onPlateSettingsChange ? (
+          <PlateSettingsControls
+            defaultStartingWeight={plateStartingWeight}
+            defaultLoadMode={plateLoadMode}
+            onSettingsChange={onPlateSettingsChange}
+          />
+        ) : null}
+      </NoteEditorDialog>
       <NoteEditorDialog
         open={workoutExerciseNoteEditorOpen}
         title={`${exerciseName} note for this workout`}

--- a/apps/web/src/components/workout-reference/previous-workout-exercise.tsx
+++ b/apps/web/src/components/workout-reference/previous-workout-exercise.tsx
@@ -20,15 +20,20 @@ import type {
   PreviousExercise,
   SetChangeOptions,
 } from "@/components/workout-reference/workout_reference_types";
+import type { PlateSettings } from "@/components/workout-reference/weight_helper_dialog";
+import type { PlateMode } from "@/lib/weight-helper";
 
 type PreviousWorkoutExerciseProps = {
   exerciseName: string;
   exerciseNote: string;
+  plateStartingWeight?: number | null;
+  plateLoadMode?: PlateMode | null;
   history: PreviousExercise[];
   initialCurrentSets?: CurrentExerciseSet[];
   workoutExerciseNote?: string;
   onExerciseNoteChange?: (note: string) => void;
   onWorkoutExerciseNoteChange?: (note: string) => void;
+  onPlateSettingsChange?: (settings: PlateSettings) => void;
   onCurrentSetsChange?: (
     sets: CurrentExerciseSet[],
     options?: SetChangeOptions,
@@ -40,11 +45,14 @@ type PreviousWorkoutExerciseProps = {
 export function PreviousWorkoutExercise({
   exerciseName,
   exerciseNote,
+  plateStartingWeight,
+  plateLoadMode,
   history,
   initialCurrentSets: initialCurrentSetsOverride,
   workoutExerciseNote = "",
   onExerciseNoteChange,
   onWorkoutExerciseNoteChange,
+  onPlateSettingsChange,
   onCurrentSetsChange,
   onCommitPendingHistory,
   shellClassName,
@@ -63,6 +71,10 @@ export function PreviousWorkoutExercise({
       <ExerciseReferenceHeader
         name={exerciseName}
         note={exerciseNote}
+        plateSettingsText={formatPlateSettingsText(
+          plateStartingWeight,
+          plateLoadMode,
+        )}
         workoutExerciseNote={workoutExerciseNote}
         hasHistory={history.length > 0}
         historyVisible={isExpanded}
@@ -76,11 +88,14 @@ export function PreviousWorkoutExercise({
       <TimelineExerciseInput
         exerciseName={exerciseName}
         initialSets={currentSets}
+        plateStartingWeight={plateStartingWeight}
+        plateLoadMode={plateLoadMode}
         restTypes={restTypes}
         workoutExerciseNote={workoutExerciseNote}
         onEditWorkoutExerciseNote={() => setWorkoutExerciseNoteEditorOpen(true)}
         onSetsChange={onCurrentSetsChange}
         onCommitPendingHistory={onCommitPendingHistory}
+        onPlateSettingsChange={onPlateSettingsChange}
       />
       <NoteEditorDialog
         open={userExerciseNoteEditorOpen}
@@ -116,4 +131,31 @@ export function PreviousWorkoutExercise({
       />
     </ExerciseReferenceShell>
   );
+}
+
+function formatPlateSettingsText(
+  startingWeight?: number | null,
+  loadMode?: PlateMode | null,
+) {
+  if (startingWeight == null && !loadMode) return "";
+
+  const start =
+    startingWeight == null
+      ? "default start"
+      : startingWeight === 0
+        ? "no start"
+        : `${formatNumber(startingWeight)}lb ${getBarLabel(startingWeight)}`;
+  const mode = loadMode === "total" ? "total load" : "equal sides";
+
+  return `${start} · ${mode}`;
+}
+
+function getBarLabel(weight: number) {
+  if ([45, 35, 33, 25, 15].includes(weight)) return "bar";
+  return "start";
+}
+
+function formatNumber(value: number) {
+  const rounded = Number(value.toFixed(1));
+  return Number.isInteger(rounded) ? String(rounded) : String(rounded);
 }

--- a/apps/web/src/components/workout-reference/set_editor_keyboard.tsx
+++ b/apps/web/src/components/workout-reference/set_editor_keyboard.tsx
@@ -23,8 +23,10 @@ import { cn } from "@/lib/utils";
 import {
   IncreaseWeightDialog,
   PlateCalculatorDialog,
+  type PlateSettings,
   type WeightSuggestion,
 } from "@/components/workout-reference/weight_helper_dialog";
+import type { PlateMode } from "@/lib/weight-helper";
 import type { CurrentExerciseSet } from "@/components/workout-reference/workout_reference_types";
 
 export function SetEditorKeyboard({
@@ -34,6 +36,9 @@ export function SetEditorKeyboard({
   onAddShortRest,
   onNext,
   onUpdate,
+  plateStartingWeight,
+  plateLoadMode,
+  onPlateSettingsChange,
 }: {
   field: "weight" | "reps";
   set: CurrentExerciseSet;
@@ -41,6 +46,9 @@ export function SetEditorKeyboard({
   onAddShortRest?: () => void;
   onNext: () => void;
   onUpdate: (set: CurrentExerciseSet) => void;
+  plateStartingWeight?: number | null;
+  plateLoadMode?: PlateMode | null;
+  onPlateSettingsChange?: (settings: PlateSettings) => void;
 }) {
   const [draftSet, setDraftSet] = useState(set);
   const draftSetRef = useRef(set);
@@ -110,12 +118,21 @@ export function SetEditorKeyboard({
           className="grid min-w-0 grid-cols-[minmax(0,1fr)_minmax(0,1fr)] gap-1"
           style={{ gridArea: "action1" }}
         >
-          <IncreaseWeightDialog set={draftSet} onUse={applyWeightSuggestion}>
+          <IncreaseWeightDialog
+            set={draftSet}
+            defaultLoadMode={plateLoadMode}
+            onUse={applyWeightSuggestion}
+          >
             <KeypadTriggerButton label="increase weight helper">
               <TrendingUp className="size-4" aria-hidden="true" />
             </KeypadTriggerButton>
           </IncreaseWeightDialog>
-          <PlateCalculatorDialog set={draftSet}>
+          <PlateCalculatorDialog
+            set={draftSet}
+            defaultStartingWeight={plateStartingWeight}
+            defaultLoadMode={plateLoadMode}
+            onSettingsChange={onPlateSettingsChange}
+          >
             <KeypadTriggerButton label="plate calculator">
               <Disc3 className="size-4" aria-hidden="true" />
             </KeypadTriggerButton>

--- a/apps/web/src/components/workout-reference/set_value_dialog.tsx
+++ b/apps/web/src/components/workout-reference/set_value_dialog.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  Dialog,
-  DialogDescription,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { Dialog, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { WorkoutEditorContent } from "@/components/workout/workout_editor_primitives";
 import { SetEditorKeyboard } from "@/components/workout-reference/set_editor_keyboard";
 import {
@@ -12,6 +8,8 @@ import {
   SetRestKeyboard,
 } from "@/components/workout-reference/set_editor_modes";
 import { SetEditorReadout } from "@/components/workout-reference/set_editor_readout";
+import type { PlateSettings } from "@/components/workout-reference/weight_helper_dialog";
+import type { PlateMode } from "@/lib/weight-helper";
 import type {
   CurrentExerciseSet,
   EditorField,
@@ -26,6 +24,8 @@ type SetValueDialogProps = {
   sets: CurrentExerciseSet[];
   restTypes: RestType[];
   setLabel: string;
+  plateStartingWeight?: number | null;
+  plateLoadMode?: PlateMode | null;
   onDelete: () => void;
   onAddSet: () => void;
   onAddShortRestSet: (setId: string) => void;
@@ -35,6 +35,7 @@ type SetValueDialogProps = {
   onOpenChange: (open: boolean) => void;
   onFieldChange: (field: EditorField) => void;
   onUpdate: (set: CurrentExerciseSet, options?: SetChangeOptions) => void;
+  onPlateSettingsChange?: (settings: PlateSettings) => void;
 };
 
 export function SetValueDialog({
@@ -44,6 +45,8 @@ export function SetValueDialog({
   sets,
   restTypes,
   setLabel,
+  plateStartingWeight,
+  plateLoadMode,
   onDelete,
   onAddSet,
   onAddShortRestSet,
@@ -53,6 +56,7 @@ export function SetValueDialog({
   onOpenChange,
   onFieldChange,
   onUpdate,
+  onPlateSettingsChange,
 }: SetValueDialogProps) {
   const open = Boolean(editor && set);
   const field = editor?.field ?? "weight";
@@ -72,6 +76,8 @@ export function SetValueDialog({
             sets={displaySets}
             restTypes={restTypes}
             setLabel={setLabel}
+            plateStartingWeight={plateStartingWeight}
+            plateLoadMode={plateLoadMode}
             field={field}
             onDelete={onDelete}
             onAddSet={onAddSet}
@@ -82,6 +88,7 @@ export function SetValueDialog({
             onOpenChange={onOpenChange}
             onFieldChange={onFieldChange}
             onUpdate={onUpdate}
+            onPlateSettingsChange={onPlateSettingsChange}
           />
         ) : null}
       </WorkoutEditorContent>
@@ -102,6 +109,8 @@ function SetValueDialogContent({
   sets,
   restTypes,
   setLabel,
+  plateStartingWeight,
+  plateLoadMode,
   field,
   onDelete,
   onAddSet,
@@ -112,6 +121,7 @@ function SetValueDialogContent({
   onOpenChange,
   onFieldChange,
   onUpdate,
+  onPlateSettingsChange,
 }: Omit<SetValueDialogProps, "editor"> & {
   set: CurrentExerciseSet;
   field: EditorField;
@@ -163,6 +173,9 @@ function SetValueDialogContent({
           key={`${set.id}-${field}`}
           field={field}
           set={set}
+          plateStartingWeight={plateStartingWeight}
+          plateLoadMode={plateLoadMode}
+          onPlateSettingsChange={onPlateSettingsChange}
           onAddShortRest={
             field === "reps" ? () => onAddShortRestSet(set.id) : undefined
           }

--- a/apps/web/src/components/workout-reference/timeline_exercise_input.tsx
+++ b/apps/web/src/components/workout-reference/timeline_exercise_input.tsx
@@ -13,6 +13,8 @@ import {
 } from "@/components/workout-reference/current_exercise_sets";
 import { getCurrentSetLabel } from "@/components/workout-reference/set_formatting";
 import { SetValueDialog } from "@/components/workout-reference/set_value_dialog";
+import type { PlateSettings } from "@/components/workout-reference/weight_helper_dialog";
+import type { PlateMode } from "@/lib/weight-helper";
 import type {
   CurrentExerciseSet,
   EditorField,
@@ -28,6 +30,8 @@ type SetEditorState = {
 type TimelineExerciseInputProps = {
   exerciseName: string;
   initialSets: CurrentExerciseSet[];
+  plateStartingWeight?: number | null;
+  plateLoadMode?: PlateMode | null;
   restTypes: RestType[];
   workoutExerciseNote: string;
   onEditWorkoutExerciseNote: () => void;
@@ -36,16 +40,20 @@ type TimelineExerciseInputProps = {
     options?: SetChangeOptions,
   ) => void;
   onCommitPendingHistory?: () => void;
+  onPlateSettingsChange?: (settings: PlateSettings) => void;
 };
 
 export function TimelineExerciseInput({
   exerciseName,
   initialSets,
+  plateStartingWeight,
+  plateLoadMode,
   restTypes,
   workoutExerciseNote,
   onEditWorkoutExerciseNote,
   onSetsChange,
   onCommitPendingHistory,
+  onPlateSettingsChange,
 }: TimelineExerciseInputProps) {
   const controlled = Boolean(onSetsChange);
   const [uncontrolledSets, setUncontrolledSets] = useState<
@@ -244,6 +252,8 @@ export function TimelineExerciseInput({
         sets={displaySets}
         restTypes={restTypes}
         setLabel={activeSetLabel}
+        plateStartingWeight={plateStartingWeight}
+        plateLoadMode={plateLoadMode}
         onDelete={() => {
           if (!activeSet) return;
           deleteSet(activeSet.id);
@@ -252,6 +262,7 @@ export function TimelineExerciseInput({
         onAddShortRestSet={addShortRestSet}
         onCycleRestBefore={cycleRestBefore}
         onUseStandardRestBefore={useStandardRestBefore}
+        onPlateSettingsChange={onPlateSettingsChange}
         onSelectSet={(setId) => {
           commitPendingHistory();
           setEditor((currentEditor) =>

--- a/apps/web/src/components/workout-reference/weight_helper_dialog.tsx
+++ b/apps/web/src/components/workout-reference/weight_helper_dialog.tsx
@@ -450,6 +450,72 @@ function PlateHelper({
   defaultLoadMode?: PlateMode | null;
   onSettingsChange?: (settings: PlateSettings) => void;
 }) {
+  const [settings, setSettings] = useState<PlateSettings>(() => ({
+    startingWeight: defaultStartingWeight ?? 45,
+    loadMode: parsePlateMode(defaultLoadMode),
+  }));
+  const startingWeight = settings.startingWeight ?? 0;
+  const mode = settings.loadMode;
+  const platePlan = calculatePlatePlan(defaultWeight, startingWeight, mode);
+
+  function updateSettings(nextSettings: PlateSettings) {
+    setSettings(nextSettings);
+    onSettingsChange?.(nextSettings);
+  }
+
+  return (
+    <div className="space-y-2 text-[12px] leading-5">
+      <div className="flex min-w-0 flex-wrap items-end gap-2">
+        <div className="space-y-1">
+          <FieldLabel>total weight</FieldLabel>
+          <div className="inline-flex h-5 items-baseline">
+            <span className="font-mono text-[16px] leading-none">
+              {formatNumber(defaultWeight)}
+            </span>
+            <span className="text-[11px] leading-none text-[#716b5d]">lb</span>
+          </div>
+        </div>
+
+        <PlateSettingsControls
+          defaultStartingWeight={settings.startingWeight}
+          defaultLoadMode={settings.loadMode}
+          onSettingsChange={updateSettings}
+        />
+      </div>
+
+      <div className="space-y-1">
+        {!platePlan.error ? <PlatePlanDisplay plan={platePlan} /> : null}
+        {platePlan?.error ? (
+          <>
+            <HelperLine
+              left="start"
+              right={
+                startingWeight > 0
+                  ? `${formatNumber(startingWeight)}lb`
+                  : "none"
+              }
+            />
+            <HelperLine
+              left={mode === "equal-sides" ? "each" : "load"}
+              right={platePlan.title}
+            />
+            <HelperLine left="-" right={platePlan.error} />
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function PlateSettingsControls({
+  defaultStartingWeight,
+  defaultLoadMode,
+  onSettingsChange,
+}: {
+  defaultStartingWeight?: number | null;
+  defaultLoadMode?: PlateMode | null;
+  onSettingsChange: (settings: PlateSettings) => void;
+}) {
   const initialStartingWeight = defaultStartingWeight ?? 45;
   const [startingWeightValue, setStartingWeightValue] =
     useState<StartingWeightValue>(() =>
@@ -463,10 +529,9 @@ function PlateHelper({
     startingWeightValue,
     customStartingWeightText,
   );
-  const platePlan = calculatePlatePlan(defaultWeight, startingWeight, mode);
 
   function saveSettings(nextStartingWeight: number, nextMode: PlateMode) {
-    onSettingsChange?.({
+    onSettingsChange({
       startingWeight: nextStartingWeight,
       loadMode: nextMode,
     });
@@ -494,56 +559,44 @@ function PlateHelper({
 
   return (
     <div className="space-y-2 text-[12px] leading-5">
-      <div className="flex min-w-0 flex-wrap items-end gap-2">
-        <div className="space-y-1">
-          <FieldLabel>total weight</FieldLabel>
-          <div className="inline-flex h-5 items-baseline">
-            <span className="font-mono text-[16px] leading-none">
-              {formatNumber(defaultWeight)}
-            </span>
-            <span className="text-[11px] leading-none text-[#716b5d]">lb</span>
-          </div>
-        </div>
-
-        <div className="min-w-0 space-y-1">
-          <FieldLabel>starting weight</FieldLabel>
-          <div className="flex flex-wrap items-center gap-1">
-            <Select
-              value={startingWeightValue}
-              onValueChange={(value) =>
-                updateStartingWeightValue(value as StartingWeightValue)
-              }
+      <div className="min-w-0 space-y-1">
+        <FieldLabel>starting weight</FieldLabel>
+        <div className="flex flex-wrap items-center gap-1">
+          <Select
+            value={startingWeightValue}
+            onValueChange={(value) =>
+              updateStartingWeightValue(value as StartingWeightValue)
+            }
+          >
+            <SelectTrigger
+              aria-label="starting weight"
+              className="!h-5 min-w-[5.25rem] !gap-1 rounded-[3px] border-[#d7cfbc] bg-[#fdfcf8] !px-1 !py-0 font-mono text-[11px] leading-none text-[#17150f] shadow-none focus:ring-[#a79b83] [&_svg]:!size-3"
             >
-              <SelectTrigger
-                aria-label="starting weight"
-                className="!h-5 min-w-[5.25rem] !gap-1 rounded-[3px] border-[#d7cfbc] bg-[#fdfcf8] !px-1 !py-0 font-mono text-[11px] leading-none text-[#17150f] shadow-none focus:ring-[#a79b83] [&_svg]:!size-3"
-              >
-                <span className="min-w-0 truncate">
-                  {getStartingWeightLabel(startingWeightValue)}
-                </span>
-              </SelectTrigger>
-              <SelectContent className="!z-[80] rounded-[4px] border-[#d7cfbc] bg-[#fdfcf8] font-mono text-[#17150f] shadow-none">
-                {BARS.map((bar) => (
-                  <SelectItem
-                    key={bar.value}
-                    value={bar.value}
-                    className="font-mono text-[12px] focus:bg-[#eee8da]"
-                  >
-                    {bar.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {startingWeightValue === "custom" ? (
-              <NumericInput
-                value={customStartingWeightText}
-                onChange={updateCustomStartingWeightText}
-                ariaLabel="custom starting weight"
-                suffix="lb"
-                className="w-[5.25rem]"
-              />
-            ) : null}
-          </div>
+              <span className="min-w-0 truncate">
+                {getStartingWeightLabel(startingWeightValue)}
+              </span>
+            </SelectTrigger>
+            <SelectContent className="!z-[80] rounded-[4px] border-[#d7cfbc] bg-[#fdfcf8] font-mono text-[#17150f] shadow-none">
+              {BARS.map((bar) => (
+                <SelectItem
+                  key={bar.value}
+                  value={bar.value}
+                  className="font-mono text-[12px] focus:bg-[#eee8da]"
+                >
+                  {bar.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {startingWeightValue === "custom" ? (
+            <NumericInput
+              value={customStartingWeightText}
+              onChange={updateCustomStartingWeightText}
+              ariaLabel="custom starting weight"
+              suffix="lb"
+              className="w-[5.25rem]"
+            />
+          ) : null}
         </div>
       </div>
 
@@ -560,27 +613,6 @@ function PlateHelper({
         >
           total load
         </SegmentedButton>
-      </div>
-
-      <div className="space-y-1">
-        {!platePlan.error ? <PlatePlanDisplay plan={platePlan} /> : null}
-        {platePlan?.error ? (
-          <>
-            <HelperLine
-              left="start"
-              right={
-                startingWeight > 0
-                  ? `${formatNumber(startingWeight)}lb`
-                  : "none"
-              }
-            />
-            <HelperLine
-              left={mode === "equal-sides" ? "each" : "load"}
-              right={platePlan.title}
-            />
-            <HelperLine left="-" right={platePlan.error} />
-          </>
-        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/components/workout-reference/weight_helper_dialog.tsx
+++ b/apps/web/src/components/workout-reference/weight_helper_dialog.tsx
@@ -62,6 +62,10 @@ export type WeightSuggestion = {
   weight: number;
   reps: number;
 };
+export type PlateSettings = {
+  startingWeight: number | null;
+  loadMode: PlateMode;
+};
 
 export function WeightHelperDialog({
   set,
@@ -84,10 +88,12 @@ export function IncreaseWeightDialog({
   set,
   children,
   onUse,
+  defaultLoadMode,
 }: {
   set: CurrentExerciseSet;
   children: ReactNode;
   onUse: (suggestion: WeightSuggestion) => void;
+  defaultLoadMode?: PlateMode | null;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -98,6 +104,7 @@ export function IncreaseWeightDialog({
         <OneRepMaxAddedWeightRepsCalculator
           set={set}
           withSectionFrame={false}
+          defaultLoadMode={defaultLoadMode}
           onUse={(suggestion) => {
             onUse(suggestion);
             setOpen(false);
@@ -111,15 +118,27 @@ export function IncreaseWeightDialog({
 export function PlateCalculatorDialog({
   set,
   children,
+  defaultStartingWeight,
+  defaultLoadMode,
+  onSettingsChange,
 }: {
   set: CurrentExerciseSet;
   children: ReactNode;
+  defaultStartingWeight?: number | null;
+  defaultLoadMode?: PlateMode | null;
+  onSettingsChange?: (settings: PlateSettings) => void;
 }) {
   return (
     <Dialog modal={false}>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <WeightHelperDialogContent title="plates" stacked>
-        <PlateLoadCalculator set={set} withSectionFrame={false} />
+        <PlateLoadCalculator
+          set={set}
+          withSectionFrame={false}
+          defaultStartingWeight={defaultStartingWeight}
+          defaultLoadMode={defaultLoadMode}
+          onSettingsChange={onSettingsChange}
+        />
       </WeightHelperDialogContent>
     </Dialog>
   );
@@ -176,10 +195,12 @@ export function OneRepMaxAddedWeightRepsCalculator({
   set,
   onUse,
   withSectionFrame = true,
+  defaultLoadMode,
 }: {
   set: CurrentExerciseSet;
   onUse?: (suggestion: WeightSuggestion) => void;
   withSectionFrame?: boolean;
+  defaultLoadMode?: PlateMode | null;
 }) {
   const defaultWeight = getDefaultWeight(set);
   const defaultReps = getDefaultReps(set);
@@ -187,6 +208,7 @@ export function OneRepMaxAddedWeightRepsCalculator({
     <AddedWeightRepsHelper
       defaultWeight={defaultWeight}
       defaultReps={defaultReps}
+      defaultLoadMode={defaultLoadMode}
       onUse={onUse}
     />
   );
@@ -203,11 +225,24 @@ export function OneRepMaxAddedWeightRepsCalculator({
 export function PlateLoadCalculator({
   set,
   withSectionFrame = true,
+  defaultStartingWeight,
+  defaultLoadMode,
+  onSettingsChange,
 }: {
   set: CurrentExerciseSet;
   withSectionFrame?: boolean;
+  defaultStartingWeight?: number | null;
+  defaultLoadMode?: PlateMode | null;
+  onSettingsChange?: (settings: PlateSettings) => void;
 }) {
-  const calculator = <PlateHelper defaultWeight={getDefaultWeight(set)} />;
+  const calculator = (
+    <PlateHelper
+      defaultWeight={getDefaultWeight(set)}
+      defaultStartingWeight={defaultStartingWeight}
+      defaultLoadMode={defaultLoadMode}
+      onSettingsChange={onSettingsChange}
+    />
+  );
 
   if (!withSectionFrame) return calculator;
 
@@ -241,13 +276,15 @@ export function WeightHelperIcon() {
 function AddedWeightRepsHelper({
   defaultWeight,
   defaultReps,
+  defaultLoadMode,
   onUse,
 }: {
   defaultWeight: number;
   defaultReps: number;
+  defaultLoadMode?: PlateMode | null;
   onUse?: (suggestion: WeightSuggestion) => void;
 }) {
-  const [mode, setMode] = useState<PlateMode>("equal-sides");
+  const [mode, setMode] = useState<PlateMode>(parsePlateMode(defaultLoadMode));
   const [addedWeight, setAddedWeight] = useState(5);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const oneRepMax = estimate1RM(defaultWeight, defaultReps);
@@ -402,16 +439,58 @@ function CurrentOneRepMaxLine({
   );
 }
 
-function PlateHelper({ defaultWeight }: { defaultWeight: number }) {
+function PlateHelper({
+  defaultWeight,
+  defaultStartingWeight,
+  defaultLoadMode,
+  onSettingsChange,
+}: {
+  defaultWeight: number;
+  defaultStartingWeight?: number | null;
+  defaultLoadMode?: PlateMode | null;
+  onSettingsChange?: (settings: PlateSettings) => void;
+}) {
+  const initialStartingWeight = defaultStartingWeight ?? 45;
   const [startingWeightValue, setStartingWeightValue] =
-    useState<StartingWeightValue>("45");
-  const [customStartingWeightText, setCustomStartingWeightText] = useState("0");
-  const [mode, setMode] = useState<PlateMode>("equal-sides");
+    useState<StartingWeightValue>(() =>
+      getStartingWeightValue(initialStartingWeight),
+    );
+  const [customStartingWeightText, setCustomStartingWeightText] = useState(() =>
+    String(initialStartingWeight),
+  );
+  const [mode, setMode] = useState<PlateMode>(parsePlateMode(defaultLoadMode));
   const startingWeight = getStartingWeight(
     startingWeightValue,
     customStartingWeightText,
   );
   const platePlan = calculatePlatePlan(defaultWeight, startingWeight, mode);
+
+  function saveSettings(nextStartingWeight: number, nextMode: PlateMode) {
+    onSettingsChange?.({
+      startingWeight: nextStartingWeight,
+      loadMode: nextMode,
+    });
+  }
+
+  function updateStartingWeightValue(value: StartingWeightValue) {
+    const nextStartingWeight = getStartingWeight(
+      value,
+      customStartingWeightText,
+    );
+    setStartingWeightValue(value);
+    saveSettings(nextStartingWeight, mode);
+  }
+
+  function updateCustomStartingWeightText(value: string) {
+    const nextStartingWeight = getStartingWeight(startingWeightValue, value);
+    setCustomStartingWeightText(value);
+    saveSettings(nextStartingWeight, mode);
+  }
+
+  function updateMode(nextMode: PlateMode) {
+    setMode(nextMode);
+    saveSettings(startingWeight, nextMode);
+  }
 
   return (
     <div className="space-y-2 text-[12px] leading-5">
@@ -432,7 +511,7 @@ function PlateHelper({ defaultWeight }: { defaultWeight: number }) {
             <Select
               value={startingWeightValue}
               onValueChange={(value) =>
-                setStartingWeightValue(value as StartingWeightValue)
+                updateStartingWeightValue(value as StartingWeightValue)
               }
             >
               <SelectTrigger
@@ -458,7 +537,7 @@ function PlateHelper({ defaultWeight }: { defaultWeight: number }) {
             {startingWeightValue === "custom" ? (
               <NumericInput
                 value={customStartingWeightText}
-                onChange={setCustomStartingWeightText}
+                onChange={updateCustomStartingWeightText}
                 ariaLabel="custom starting weight"
                 suffix="lb"
                 className="w-[5.25rem]"
@@ -471,13 +550,13 @@ function PlateHelper({ defaultWeight }: { defaultWeight: number }) {
       <div className="flex flex-wrap gap-1">
         <SegmentedButton
           active={mode === "equal-sides"}
-          onClick={() => setMode("equal-sides")}
+          onClick={() => updateMode("equal-sides")}
         >
           equal sides
         </SegmentedButton>
         <SegmentedButton
           active={mode === "total"}
-          onClick={() => setMode("total")}
+          onClick={() => updateMode("total")}
         >
           total load
         </SegmentedButton>
@@ -779,8 +858,19 @@ function getStartingWeight(
   return BARS.find((bar) => bar.value === value)?.weight ?? 0;
 }
 
+function getStartingWeightValue(weight: number): StartingWeightValue {
+  return (
+    BARS.find((bar) => bar.weight === weight)?.value ??
+    (weight === 0 ? "none" : "custom")
+  );
+}
+
 function getStartingWeightLabel(value: StartingWeightValue) {
   return BARS.find((bar) => bar.value === value)?.label ?? "none";
+}
+
+function parsePlateMode(value: PlateMode | null | undefined): PlateMode {
+  return value === "total" ? "total" : "equal-sides";
 }
 
 function getDefaultWeight(set: CurrentExerciseSet) {

--- a/apps/web/src/components/workout-reference/workout_reference_sandbox.tsx
+++ b/apps/web/src/components/workout-reference/workout_reference_sandbox.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { PreviousWorkoutExercise } from "@/components/workout-reference/previous-workout-exercise";
+import type { PlateSettings } from "@/components/workout-reference/weight_helper_dialog";
 import type {
   CurrentExerciseSet,
   PreviousExercise,
@@ -148,6 +149,11 @@ const sampleCurrentSets: CurrentExerciseSet[] = [
 ];
 
 export function PreviousWorkoutExerciseSandbox() {
+  const [plateSettings, setPlateSettings] = useState<PlateSettings>({
+    startingWeight: 0,
+    loadMode: "total",
+  });
+
   useEffect(() => {
     let metaViewport = document.querySelector('meta[name="viewport"]');
     const previousViewportContent =
@@ -186,8 +192,11 @@ export function PreviousWorkoutExerciseSandbox() {
       <PreviousWorkoutExercise
         exerciseName="Pull-ups"
         exerciseNote="Hold dumbbell in thighs"
+        plateStartingWeight={plateSettings.startingWeight}
+        plateLoadMode={plateSettings.loadMode}
         history={sampleHistory}
         initialCurrentSets={sampleCurrentSets}
+        onPlateSettingsChange={setPlateSettings}
       />
     </div>
   );

--- a/apps/web/src/components/workout/note_editor_dialog.tsx
+++ b/apps/web/src/components/workout/note_editor_dialog.tsx
@@ -2,11 +2,7 @@
 
 import type { ReactNode } from "react";
 import { useState } from "react";
-import {
-  Dialog,
-  DialogDescription,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { Dialog, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import {
   ConfirmableNoteDeleteAction,
   NoteEditorActions,
@@ -23,6 +19,7 @@ export function NoteEditorDialog({
   label,
   note,
   deleteLabel,
+  children,
   onOpenChange,
   onSave,
   onDelete,
@@ -33,6 +30,7 @@ export function NoteEditorDialog({
   label: ReactNode;
   note: string;
   deleteLabel: string;
+  children?: ReactNode;
   onOpenChange: (open: boolean) => void;
   onSave: (note: string) => void;
   onDelete: () => void;
@@ -47,6 +45,7 @@ export function NoteEditorDialog({
           label={label}
           note={note}
           deleteLabel={deleteLabel}
+          controls={children}
           onOpenChange={onOpenChange}
           onSave={onSave}
           onDelete={onDelete}
@@ -62,6 +61,7 @@ function NoteEditorDialogContent({
   label,
   note,
   deleteLabel,
+  controls,
   onOpenChange,
   onSave,
   onDelete,
@@ -71,6 +71,7 @@ function NoteEditorDialogContent({
   label: ReactNode;
   note: string;
   deleteLabel: string;
+  controls?: ReactNode;
   onOpenChange: (open: boolean) => void;
   onSave: (note: string) => void;
   onDelete: () => void;
@@ -110,6 +111,7 @@ function NoteEditorDialogContent({
         className="min-h-24 w-full resize-none rounded-[4px] border border-[#d7cfbc] bg-[#fdfcf8] px-2 py-1 font-mono text-[16px] leading-5 text-[#17150f] outline-none focus:ring-1 focus:ring-[#a79b83]"
         onChange={(event) => setDraft(event.target.value)}
       />
+      {controls}
       <NoteEditorActions onDone={save}>
         {note.trim() ? (
           <ConfirmableNoteDeleteAction

--- a/apps/web/src/components/workout/workout.tsx
+++ b/apps/web/src/components/workout/workout.tsx
@@ -24,12 +24,14 @@ import {
   type WeightModifier,
   type SetModifier,
   type CompletedWorkout,
+  type PlateLoadMode,
 } from "@lift-prog/workout-core";
 import { FinishDialog } from "./finish_dialog";
 import { WorkoutHeader } from "@/components/workout/workout_header";
 import { useWorkoutPersistence } from "@/components/workout/use_workout_persistence";
 import { useWorkoutFinishDialog } from "@/components/workout/use_workout_finish_dialog";
 import { WorkoutExerciseList } from "@/components/workout/workout_exercise_list";
+import type { PlateSettings } from "@/components/workout-reference/weight_helper_dialog";
 
 interface PreviousExerciseData {
   userExerciseId?: number;
@@ -46,6 +48,8 @@ interface PreviousExerciseData {
   exerciseNotes?: string | null;
   notes?: string | null;
   exerciseNotesSnapshot?: string | null;
+  plateStartingWeight?: number | null;
+  plateLoadMode?: PlateLoadMode | string | null;
   history?: Workout["exercises"][number]["history"];
 }
 
@@ -162,8 +166,10 @@ function workoutDraftReducer(
 
     return {
       ...session,
-      past: [...session.past, cloneWorkoutDraft(session.pendingHistoryBase)]
-        .slice(-MAX_DRAFT_HISTORY),
+      past: [
+        ...session.past,
+        cloneWorkoutDraft(session.pendingHistoryBase),
+      ].slice(-MAX_DRAFT_HISTORY),
       future: [],
       pendingHistoryBase: undefined,
     };
@@ -407,8 +413,7 @@ function WorkoutComponentInner({
   });
 
   const [workoutNoteEditorOpen, setWorkoutNoteEditorOpen] = useState(false);
-  const [deleteWorkoutDialogOpen, setDeleteWorkoutDialogOpen] =
-    useState(false);
+  const [deleteWorkoutDialogOpen, setDeleteWorkoutDialogOpen] = useState(false);
   const [addingExerciseName, setAddingExerciseName] = useState<string | null>(
     null,
   );
@@ -478,6 +483,15 @@ function WorkoutComponentInner({
       toast.error(`Error updating exercise note: ${error.message}`);
     },
   });
+  const updateUserExercisePlateDefaultsMutation =
+    api.exercise.updatePlateDefaults.useMutation({
+      onSuccess: async () => {
+        await utils.exercise.list.invalidate();
+      },
+      onError: (error) => {
+        toast.error(`Error updating plate defaults: ${error.message}`);
+      },
+    });
 
   const discardWorkoutChanges = () => {
     if (
@@ -621,6 +635,41 @@ function WorkoutComponentInner({
     }
   };
 
+  const updateUserExercisePlateDefaults = (
+    exerciseIndex: number,
+    settings: PlateSettings,
+  ) => {
+    const exercise = state.exercises[exerciseIndex];
+    if (!exercise) return;
+
+    dispatch(
+      {
+        type: "UPDATE_USER_EXERCISE_PLATE_DEFAULTS",
+        exerciseIndex,
+        plateStartingWeight: settings.startingWeight,
+        plateLoadMode: settings.loadMode,
+      },
+      { track: false },
+    );
+
+    const payload = {
+      plateStartingWeight: settings.startingWeight,
+      plateLoadMode: settings.loadMode,
+    };
+
+    if (exercise.userExerciseId) {
+      updateUserExercisePlateDefaultsMutation.mutate({
+        id: exercise.userExerciseId,
+        ...payload,
+      });
+    } else {
+      updateUserExercisePlateDefaultsMutation.mutate({
+        name: exercise.name,
+        ...payload,
+      });
+    }
+  };
+
   const buildFinishedWorkoutPayload = (): CompletedWorkout => {
     const durationInSeconds = finishDialog.getDurationInSeconds(
       state.startTime,
@@ -749,6 +798,7 @@ function WorkoutComponentInner({
       <WorkoutExerciseList
         exercises={state.exercises}
         onExerciseNoteChange={updateUserExerciseNote}
+        onPlateSettingsChange={updateUserExercisePlateDefaults}
         onWorkoutExerciseNoteChange={updateWorkoutExerciseNote}
         onCommitPendingHistory={commitPendingHistory}
         onCurrentSetsChange={(exerciseIndex, sets, options) =>

--- a/apps/web/src/components/workout/workout.tsx
+++ b/apps/web/src/components/workout/workout.tsx
@@ -24,7 +24,6 @@ import {
   type WeightModifier,
   type SetModifier,
   type CompletedWorkout,
-  type PlateLoadMode,
 } from "@lift-prog/workout-core";
 import { FinishDialog } from "./finish_dialog";
 import { WorkoutHeader } from "@/components/workout/workout_header";
@@ -49,7 +48,7 @@ interface PreviousExerciseData {
   notes?: string | null;
   exerciseNotesSnapshot?: string | null;
   plateStartingWeight?: number | null;
-  plateLoadMode?: PlateLoadMode | string | null;
+  plateLoadMode?: string | null;
   history?: Workout["exercises"][number]["history"];
 }
 

--- a/apps/web/src/components/workout/workout_exercise_list.tsx
+++ b/apps/web/src/components/workout/workout_exercise_list.tsx
@@ -5,6 +5,7 @@ import type {
   CurrentExerciseSet,
   SetChangeOptions,
 } from "@/components/workout-reference/workout_reference_types";
+import type { PlateSettings } from "@/components/workout-reference/weight_helper_dialog";
 import {
   buildReferenceHistory,
   normalizeCurrentSetOrder,
@@ -15,6 +16,10 @@ import type { Workout } from "@lift-prog/workout-core";
 type WorkoutExerciseListProps = {
   exercises: Workout["exercises"];
   onExerciseNoteChange: (exerciseIndex: number, note: string) => void;
+  onPlateSettingsChange: (
+    exerciseIndex: number,
+    settings: PlateSettings,
+  ) => void;
   onWorkoutExerciseNoteChange: (exerciseIndex: number, note: string) => void;
   onCurrentSetsChange: (
     exerciseIndex: number,
@@ -27,6 +32,7 @@ type WorkoutExerciseListProps = {
 export function WorkoutExerciseList({
   exercises,
   onExerciseNoteChange,
+  onPlateSettingsChange,
   onWorkoutExerciseNoteChange,
   onCurrentSetsChange,
   onCommitPendingHistory,
@@ -39,6 +45,7 @@ export function WorkoutExerciseList({
             exercise={exercise}
             exerciseIndex={exerciseIndex}
             onExerciseNoteChange={onExerciseNoteChange}
+            onPlateSettingsChange={onPlateSettingsChange}
             onWorkoutExerciseNoteChange={onWorkoutExerciseNoteChange}
             onCurrentSetsChange={onCurrentSetsChange}
             onCommitPendingHistory={onCommitPendingHistory}
@@ -53,6 +60,7 @@ function WorkoutExerciseReference({
   exercise,
   exerciseIndex,
   onExerciseNoteChange,
+  onPlateSettingsChange,
   onWorkoutExerciseNoteChange,
   onCurrentSetsChange,
   onCommitPendingHistory,
@@ -60,6 +68,10 @@ function WorkoutExerciseReference({
   exercise: Workout["exercises"][number];
   exerciseIndex: number;
   onExerciseNoteChange: (exerciseIndex: number, note: string) => void;
+  onPlateSettingsChange: (
+    exerciseIndex: number,
+    settings: PlateSettings,
+  ) => void;
   onWorkoutExerciseNoteChange: (exerciseIndex: number, note: string) => void;
   onCurrentSetsChange: (
     exerciseIndex: number,
@@ -72,10 +84,15 @@ function WorkoutExerciseReference({
     <PreviousWorkoutExercise
       exerciseName={exercise.name}
       exerciseNote={exercise.exerciseNotes ?? ""}
+      plateStartingWeight={exercise.plateStartingWeight ?? null}
+      plateLoadMode={exercise.plateLoadMode ?? null}
       history={buildReferenceHistory(exercise)}
       shellClassName="min-h-0 max-w-none bg-transparent p-0"
       workoutExerciseNote={exercise.notes[0]?.text ?? ""}
       onExerciseNoteChange={(note) => onExerciseNoteChange(exerciseIndex, note)}
+      onPlateSettingsChange={(settings) =>
+        onPlateSettingsChange(exerciseIndex, settings)
+      }
       onWorkoutExerciseNoteChange={(note) =>
         onWorkoutExerciseNoteChange(exerciseIndex, note)
       }

--- a/apps/web/src/server/api/routers/exercise.ts
+++ b/apps/web/src/server/api/routers/exercise.ts
@@ -3,6 +3,8 @@ import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
 import { normalizeExerciseNameForCompare } from "@/lib/exercise-name";
 import { TRPCError } from "@trpc/server";
 
+const plateLoadModeInput = z.enum(["equal-sides", "total"]);
+
 export const exerciseRouter = createTRPCRouter({
   // Procedure to list the signed-in user's exercise library
   list: protectedProcedure.query(async ({ ctx }) => {
@@ -17,6 +19,8 @@ export const exerciseRouter = createTRPCRouter({
         name: true,
         notes: true,
         exerciseId: true,
+        plateStartingWeight: true,
+        plateLoadMode: true,
       },
     });
   }),
@@ -167,6 +171,117 @@ export const exerciseRouter = createTRPCRouter({
           name,
           exerciseId: catalogExercise?.id ?? null,
           notes,
+        },
+      });
+
+      return { count: 1 };
+    }),
+
+  updatePlateDefaults: protectedProcedure
+    .input(
+      z
+        .object({
+          id: z.number().optional(),
+          name: z.string().min(1).optional(),
+          plateStartingWeight: z.number().min(0).nullable(),
+          plateLoadMode: plateLoadModeInput,
+        })
+        .refine((input) => input.id !== undefined || input.name !== undefined, {
+          message: "Exercise id or name is required.",
+        }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.userId;
+      if (!userId) throw new Error("User not found.");
+
+      const data = {
+        plateStartingWeight: input.plateStartingWeight,
+        plateLoadMode: input.plateLoadMode,
+      };
+
+      if (input.id !== undefined) {
+        const result = await ctx.db.userExercise.updateMany({
+          where: {
+            id: input.id,
+            userId,
+          },
+          data,
+        });
+
+        if (result.count === 0) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Exercise not found.",
+          });
+        }
+
+        return result;
+      }
+
+      const name = input.name?.trim();
+      if (!name) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Exercise name cannot be empty.",
+        });
+      }
+
+      const normalizedName = normalizeExerciseNameForCompare(name);
+      const userExercises = await ctx.db.userExercise.findMany({
+        where: { userId },
+        orderBy: { name: "asc" },
+        select: { id: true, name: true },
+      });
+      const matches = userExercises.filter(
+        (exercise) =>
+          normalizeExerciseNameForCompare(exercise.name) === normalizedName,
+      );
+
+      if (matches.length > 1) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: `Multiple user exercises match "${name}". Merge duplicates before updating plate defaults.`,
+        });
+      }
+
+      const existing = matches[0] ?? null;
+      if (existing) {
+        const result = await ctx.db.userExercise.updateMany({
+          where: {
+            id: existing.id,
+            userId,
+          },
+          data,
+        });
+
+        if (result.count === 0) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Exercise not found.",
+          });
+        }
+
+        return result;
+      }
+
+      const catalogExercise = await ctx.db.exercise.findUnique({
+        where: { name },
+        select: { id: true },
+      });
+
+      await ctx.db.userExercise.upsert({
+        where: {
+          userId_name: {
+            userId,
+            name,
+          },
+        },
+        update: data,
+        create: {
+          userId,
+          name,
+          exerciseId: catalogExercise?.id ?? null,
+          ...data,
         },
       });
 

--- a/apps/web/src/server/services/workout-initializer.ts
+++ b/apps/web/src/server/services/workout-initializer.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "@prisma/client";
 import { normalizeExerciseNameForCompare } from "@/lib/exercise-name";
+import { parsePlateLoadMode } from "@lift-prog/workout-core";
 import type {
   PreviousExerciseData,
   SetModifier,
@@ -206,11 +207,15 @@ function buildExerciseFromHistory({
   userExerciseId,
   name,
   exerciseNotes,
+  plateStartingWeight,
+  plateLoadMode,
   historyRecords,
 }: {
   userExerciseId: number;
   name: string;
   exerciseNotes: string | null;
+  plateStartingWeight?: number | null;
+  plateLoadMode?: string | null;
   historyRecords: WorkoutExerciseHistoryRecord[];
 }): PreviousExerciseData {
   const latestExercise = historyRecords[0] ?? null;
@@ -224,6 +229,8 @@ function buildExerciseFromHistory({
       name,
       sets: DEFAULT_EXERCISE_SETS.map((set) => ({ ...set })),
       ...(exerciseNotes ? { exerciseNotes } : {}),
+      plateStartingWeight: plateStartingWeight ?? null,
+      plateLoadMode: plateLoadMode ? parsePlateLoadMode(plateLoadMode) : null,
       notes: previousNotes,
       ...(latestExercise?.exerciseNotesSnapshot
         ? { exerciseNotesSnapshot: latestExercise.exerciseNotesSnapshot }
@@ -237,6 +244,8 @@ function buildExerciseFromHistory({
     name,
     sets: completedSets.map((set) => mapSet(set)),
     ...(exerciseNotes ? { exerciseNotes } : {}),
+    plateStartingWeight: plateStartingWeight ?? null,
+    plateLoadMode: plateLoadMode ? parsePlateLoadMode(plateLoadMode) : null,
     notes: previousNotes,
     ...(latestExercise.exerciseNotesSnapshot
       ? { exerciseNotesSnapshot: latestExercise.exerciseNotesSnapshot }
@@ -265,16 +274,19 @@ export async function buildInitialExercisesForNames({
         userId,
       },
       orderBy: { name: "asc" },
-      select: { id: true, name: true, notes: true },
+      select: {
+        id: true,
+        name: true,
+        notes: true,
+        plateStartingWeight: true,
+        plateLoadMode: true,
+      },
     })
   ).filter((exercise) =>
     requestedNames.has(normalizeExerciseNameForCompare(exercise.name)),
   );
 
-  const userExerciseByName = new Map<
-    string,
-    (typeof userExercises)[number]
-  >();
+  const userExerciseByName = new Map<string, (typeof userExercises)[number]>();
   for (const exercise of userExercises) {
     const normalizedName = normalizeExerciseNameForCompare(exercise.name);
     if (userExerciseByName.has(normalizedName)) {
@@ -307,6 +319,8 @@ export async function buildInitialExercisesForNames({
       userExerciseId: userExercise.id,
       name: userExercise.name,
       exerciseNotes: userExercise.notes ?? null,
+      plateStartingWeight: userExercise.plateStartingWeight,
+      plateLoadMode: userExercise.plateLoadMode,
       historyRecords: historiesByUserExerciseId.get(userExercise.id) ?? [],
     });
   });
@@ -343,7 +357,13 @@ export async function buildInitialExercisesFromWorkout({
           notes: true,
           exerciseNotesSnapshot: true,
           userExercise: {
-            select: { id: true, name: true, notes: true },
+            select: {
+              id: true,
+              name: true,
+              notes: true,
+              plateStartingWeight: true,
+              plateLoadMode: true,
+            },
           },
           sets: {
             orderBy: { order: "asc" },
@@ -393,6 +413,11 @@ export async function buildInitialExercisesFromWorkout({
           ...(workoutExercise.userExercise.notes
             ? { exerciseNotes: workoutExercise.userExercise.notes }
             : {}),
+          plateStartingWeight:
+            workoutExercise.userExercise.plateStartingWeight ?? null,
+          plateLoadMode: workoutExercise.userExercise.plateLoadMode
+            ? parsePlateLoadMode(workoutExercise.userExercise.plateLoadMode)
+            : null,
           notes: preserveInstanceNotes ? workoutExercise.notes : null,
           ...(workoutExercise.exerciseNotesSnapshot
             ? { exerciseNotesSnapshot: workoutExercise.exerciseNotesSnapshot }
@@ -405,6 +430,9 @@ export async function buildInitialExercisesFromWorkout({
         userExerciseId: workoutExercise.userExercise.id,
         name,
         exerciseNotes: workoutExercise.userExercise.notes ?? null,
+        plateStartingWeight:
+          workoutExercise.userExercise.plateStartingWeight ?? null,
+        plateLoadMode: workoutExercise.userExercise.plateLoadMode,
         historyRecords: exerciseHistory,
       });
 

--- a/apps/web/test/exerciseRouter.test.ts
+++ b/apps/web/test/exerciseRouter.test.ts
@@ -40,7 +40,9 @@ const makeCaller = () => {
 describe("exercise.add", () => {
   it("rejects a new exercise when an existing name differs only by case", async () => {
     const { caller, spies } = makeCaller();
-    spies.userExerciseFindMany.mockResolvedValue([{ id: 44, name: "Pull-ups" }]);
+    spies.userExerciseFindMany.mockResolvedValue([
+      { id: 44, name: "Pull-ups" },
+    ]);
 
     await expect(caller.exercise.add({ name: "pull-ups" })).rejects.toThrow(
       'Exercise named "Pull-ups" already exists.',
@@ -53,7 +55,9 @@ describe("exercise.add", () => {
 describe("exercise.updateNote", () => {
   it("updates an existing exercise when name fallback differs only by case", async () => {
     const { caller, spies } = makeCaller();
-    spies.userExerciseFindMany.mockResolvedValue([{ id: 44, name: "Pull-ups" }]);
+    spies.userExerciseFindMany.mockResolvedValue([
+      { id: 44, name: "Pull-ups" },
+    ]);
 
     await caller.exercise.updateNote({
       name: "pull-ups",
@@ -69,7 +73,9 @@ describe("exercise.updateNote", () => {
 
   it("rejects when name fallback resolves but no row is updated", async () => {
     const { caller, spies } = makeCaller();
-    spies.userExerciseFindMany.mockResolvedValue([{ id: 44, name: "Pull-ups" }]);
+    spies.userExerciseFindMany.mockResolvedValue([
+      { id: 44, name: "Pull-ups" },
+    ]);
     spies.userExerciseUpdateMany.mockResolvedValue({ count: 0 });
 
     await expect(
@@ -78,5 +84,29 @@ describe("exercise.updateNote", () => {
         note: "Hold dumbbell in thighs",
       }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});
+
+describe("exercise.updatePlateDefaults", () => {
+  it("updates an existing exercise when name fallback differs only by case", async () => {
+    const { caller, spies } = makeCaller();
+    spies.userExerciseFindMany.mockResolvedValue([
+      { id: 44, name: "Pull-ups" },
+    ]);
+
+    await caller.exercise.updatePlateDefaults({
+      name: "pull-ups",
+      plateStartingWeight: 45,
+      plateLoadMode: "equal-sides",
+    });
+
+    expect(spies.userExerciseUpdateMany).toHaveBeenCalledWith({
+      where: { id: 44, userId: "user_123" },
+      data: {
+        plateStartingWeight: 45,
+        plateLoadMode: "equal-sides",
+      },
+    });
+    expect(spies.userExerciseUpsert).not.toHaveBeenCalled();
   });
 });

--- a/packages/workout-core/src/workout-logic.ts
+++ b/packages/workout-core/src/workout-logic.ts
@@ -16,6 +16,7 @@ import { summarizeWorkingSets } from "./workout-summary";
 export type SetModifier = "warmup";
 export type WeightModifier = "bodyweight"; // New type for weight modifier
 export type SetRestType = "standard" | "short";
+export type PlateLoadMode = "equal-sides" | "total";
 
 export interface Note {
   text: string;
@@ -41,6 +42,8 @@ export interface WorkoutExercise {
   userExerciseId?: number;
   name: string;
   exerciseNotes?: string | null;
+  plateStartingWeight?: number | null;
+  plateLoadMode?: PlateLoadMode | null;
   sets: WorkoutSet[];
   previousSets: Array<{
     weight: number | null;
@@ -539,6 +542,8 @@ export const initialiseExercises = (
       rir?: number | null;
     }>;
     exerciseNotes?: string | null;
+    plateStartingWeight?: number | null;
+    plateLoadMode?: PlateLoadMode | string | null;
     notes?: string | null;
     exerciseNotesSnapshot?: string | null;
     history?: WorkoutExercise["history"];
@@ -562,6 +567,10 @@ export const initialiseExercises = (
       userExerciseId: ex.userExerciseId,
       name: ex.name,
       exerciseNotes: ex.exerciseNotes,
+      plateStartingWeight: ex.plateStartingWeight ?? null,
+      plateLoadMode: ex.plateLoadMode
+        ? parsePlateLoadMode(ex.plateLoadMode)
+        : null,
       sets: ex.sets.map((s) => {
         const modifier = s.modifier ?? (s.isWarmup ? "warmup" : undefined);
         const isPrevBodyweight = s.weightModifier === "bodyweight";
@@ -594,6 +603,12 @@ export const initialiseExercises = (
       notes: [],
     } satisfies WorkoutExercise;
   });
+
+export function parsePlateLoadMode(
+  value: string | null | undefined,
+): PlateLoadMode {
+  return value === "total" ? "total" : "equal-sides";
+}
 
 /**
  * Get previous workout data for a set based on its position
@@ -742,6 +757,12 @@ export type Action =
   | { type: "NAV_EXERCISE"; direction: 1 | -1 }
   | { type: "COLLAPSE_KEYBOARD" }
   | { type: "UPDATE_USER_EXERCISE_NOTE"; exerciseIndex: number; note: string }
+  | {
+      type: "UPDATE_USER_EXERCISE_PLATE_DEFAULTS";
+      exerciseIndex: number;
+      plateStartingWeight: number | null;
+      plateLoadMode: PlateLoadMode;
+    }
   | { type: "ADD_EXERCISE_NOTE"; exerciseIndex: number; text: string }
   | { type: "ADD_WORKOUT_NOTE"; text: string }
   | { type: "UPDATE_NOTES"; exerciseIndex: number; notes: string }
@@ -1403,6 +1424,26 @@ export const workoutReducer = (state: Workout, action: Action): Workout => {
       const updatedExercise: WorkoutExercise = {
         ...exercise,
         exerciseNotes: action.note.trim(),
+      };
+
+      return {
+        ...state,
+        exercises: replaceExercise(
+          state.exercises,
+          action.exerciseIndex,
+          updatedExercise,
+        ),
+      };
+    }
+
+    case "UPDATE_USER_EXERCISE_PLATE_DEFAULTS": {
+      const exercise = state.exercises[action.exerciseIndex];
+      if (!exercise) return state;
+
+      const updatedExercise: WorkoutExercise = {
+        ...exercise,
+        plateStartingWeight: action.plateStartingWeight,
+        plateLoadMode: action.plateLoadMode,
       };
 
       return {

--- a/prisma/migrations/20260619143000_user_exercise_plate_defaults/migration.sql
+++ b/prisma/migrations/20260619143000_user_exercise_plate_defaults/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "UserExercise" ADD COLUMN "plateStartingWeight" REAL;
+ALTER TABLE "UserExercise" ADD COLUMN "plateLoadMode" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,16 +45,18 @@ model Exercise {
 }
 
 model UserExercise {
-  id               Int               @id @default(autoincrement())
-  userId           String
-  exerciseId       Int?
-  name             String
-  notes            String?
-  createdAt        DateTime          @default(now())
-  updatedAt        DateTime          @updatedAt
-  user             User              @relation(fields: [userId], references: [id], onDelete: Cascade)
-  exercise         Exercise?         @relation(fields: [exerciseId], references: [id], onDelete: SetNull)
-  workoutExercises WorkoutExercise[]
+  id                  Int               @id @default(autoincrement())
+  userId              String
+  exerciseId          Int?
+  name                String
+  notes               String?
+  plateStartingWeight Float?
+  plateLoadMode       String?
+  createdAt           DateTime          @default(now())
+  updatedAt           DateTime          @updatedAt
+  user                User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  exercise            Exercise?         @relation(fields: [exerciseId], references: [id], onDelete: SetNull)
+  workoutExercises    WorkoutExercise[]
 
   @@unique([userId, name])
   @@index([exerciseId])


### PR DESCRIPTION
## Summary
- Add UserExercise plate defaults for starting weight and load mode, including the existing migration file.
- Reuse the plate settings controls inside the pinned exercise note dialog.
- Keep the workout-specific note dialog unchanged and update the reference sandbox so the new controls are visible there.

## Validation
- `npm run typecheck -w @lift-prog/web`
- `npm run test -w @lift-prog/web -- exerciseRouter.test.ts`
- Browser smoke on `http://127.0.0.1:3011/workout-reference`: opened pinned exercise note editor and confirmed starting weight/load mode controls render; opened plate calculator and confirmed it still renders with shared controls.

## Notes
- The migration SQL in this branch has already been applied to prod Turso (`UserExercise.plateStartingWeight`, `UserExercise.plateLoadMode`).
- This intentionally does not snapshot plate settings onto each workout; the settings remain user-exercise metadata.