### PR TITLE
[codex] Add exercise history stats and body weight

### DIFF
--- a/apps/web/src/app/workout/[workoutId]/edit/page.tsx
+++ b/apps/web/src/app/workout/[workoutId]/edit/page.tsx
@@ -52,6 +52,7 @@ export default function EditWorkoutPage() {
       completedAt={
         workout.completedAt ? new Date(workout.completedAt) : undefined
       }
+      bodyWeightLb={workout.bodyWeightLb ?? null}
       workoutNote={workout.notes ?? ""}
       contextLabel={`editing past workout #${workoutId}`}
       persistDraft={false}

--- a/apps/web/src/app/workout/page.tsx
+++ b/apps/web/src/app/workout/page.tsx
@@ -235,6 +235,7 @@ function WorkoutLoader({
   return (
     <WorkoutComponent
       workoutName={data.workoutName}
+      bodyWeightLb={data.bodyWeightLb ?? null}
       exercises={data.exercises}
       onInitialSave={onInitialSave}
     />

--- a/apps/web/src/components/workout-reference/workout_history.tsx
+++ b/apps/web/src/components/workout-reference/workout_history.tsx
@@ -13,7 +13,12 @@ import {
   TimelineFootnoteMarker,
   TimelineFootnoteRef,
 } from "@/components/workout-reference/timeline_notes";
+import {
+  ChartContainer,
+  type ChartConfig,
+} from "@/components/ui/chart";
 import { estimate1RM } from "@lift-prog/workout-core";
+import { LabelList, Line, LineChart, XAxis, YAxis } from "recharts";
 
 export function HistoryDisclosure({
   expanded,
@@ -112,13 +117,16 @@ export function HistoryViewport({ history }: { history: PreviousExercise[] }) {
 }
 
 type HistoryStats = {
-  count: number;
-  primaryLabel: string;
-  primaryTrend: string;
-  volumeTrend: string;
+  chartCount: number;
+  e1rmPoints: HistoryChartPoint[];
+  volumePoints: HistoryChartPoint[];
   bestSet: string;
-  frequency: string;
-  sparkline: number[];
+};
+
+type HistoryChartPoint = {
+  label: string;
+  value: number;
+  displayValue: string;
 };
 
 function HistoryStatsItem({
@@ -131,17 +139,16 @@ function HistoryStatsItem({
   return (
     <article
       ref={refCallback}
-      className="flex min-w-full snap-start flex-col gap-1 pr-1 text-[12px] leading-4"
+      className="flex min-w-full snap-start flex-col gap-1.5 pr-1 text-[12px] leading-4"
     >
       <p className="text-[12px] leading-4 text-[#716b5d]">
-        stats · {stats.count} workouts
+        stats · last {stats.chartCount}{" "}
+        {stats.chartCount === 1 ? "workout" : "workouts"}
       </p>
-      <MiniSparkline values={stats.sparkline} />
+      <HistoryTinyChart title="expected 1rm" points={stats.e1rmPoints} />
+      <HistoryTinyChart title="volume" points={stats.volumePoints} />
       <div className="grid gap-0.5">
-        <StatsLine label={stats.primaryLabel} value={stats.primaryTrend} />
-        <StatsLine label="best" value={stats.bestSet} />
-        <StatsLine label="volume" value={stats.volumeTrend} />
-        <StatsLine label="seen" value={stats.frequency} />
+        <StatsLine label="best set" value={stats.bestSet} />
       </div>
     </article>
   );
@@ -156,40 +163,81 @@ function StatsLine({ label, value }: { label: string; value: string }) {
   );
 }
 
-function MiniSparkline({ values }: { values: number[] }) {
-  if (values.length < 2) {
-    return <div className="h-6 text-[11px] text-[#8a8373]">more data soon</div>;
-  }
+const historyChartConfig = {
+  value: {
+    label: "pounds",
+    color: "#a79b83",
+  },
+} satisfies ChartConfig;
 
+function HistoryTinyChart({
+  title,
+  points,
+}: {
+  title: string;
+  points: HistoryChartPoint[];
+}) {
+  return (
+    <div className="flex flex-col gap-px">
+      <p className="text-[10px] leading-3 text-[#8a8373] lowercase">{title}</p>
+      {points.length > 0 ? (
+        <ChartContainer
+          config={historyChartConfig}
+          className="h-12 w-full aspect-auto text-[10px]"
+          aria-label={`${title}: ${points
+            .map((point) => point.displayValue)
+            .join(", ")}`}
+        >
+          <LineChart
+            data={points}
+            margin={{ top: 18, right: 14, bottom: 2, left: 14 }}
+          >
+            <XAxis dataKey="label" hide />
+            <YAxis hide domain={getChartDomain(points)} />
+            <Line
+              dataKey="value"
+              type="monotone"
+              stroke="var(--color-value)"
+              strokeWidth={1.5}
+              dot={{
+                r: 2.5,
+                strokeWidth: 0,
+                fill: "var(--color-value)",
+              }}
+              activeDot={false}
+              isAnimationActive={false}
+            >
+              <LabelList
+                dataKey="displayValue"
+                position="top"
+                offset={4}
+                fill="#716b5d"
+                fontSize={10}
+              />
+            </Line>
+          </LineChart>
+        </ChartContainer>
+      ) : (
+        <div className="h-12 text-[11px] leading-4 text-[#8a8373]">
+          more data soon
+        </div>
+      )}
+    </div>
+  );
+}
+
+function getChartDomain(points: HistoryChartPoint[]) {
+  const values = points.map((point) => point.value);
   const min = Math.min(...values);
   const max = Math.max(...values);
-  const range = max - min || 1;
-  const width = 160;
-  const height = 24;
-  const points = values
-    .map((value, index) => {
-      const x = values.length === 1 ? 0 : (index / (values.length - 1)) * width;
-      const y = height - ((value - min) / range) * (height - 4) - 2;
-      return `${roundSvgPoint(x)},${roundSvgPoint(y)}`;
-    })
-    .join(" ");
 
-  return (
-    <svg
-      aria-hidden="true"
-      className="h-6 w-full overflow-visible"
-      viewBox={`0 0 ${width} ${height}`}
-      preserveAspectRatio="none"
-    >
-      <polyline
-        points={points}
-        fill="none"
-        stroke="#a79b83"
-        strokeWidth="1.5"
-        vectorEffect="non-scaling-stroke"
-      />
-    </svg>
-  );
+  if (min === max) {
+    const padding = Math.max(1, min * 0.1);
+    return [Math.max(0, min - padding), max + padding];
+  }
+
+  const padding = (max - min) * 0.2;
+  return [Math.max(0, min - padding), max + padding];
 }
 
 function HistoryItem({
@@ -366,17 +414,24 @@ type ParsedWorkoutStats = {
 function buildHistoryStats(history: PreviousExercise[]): HistoryStats | null {
   if (history.length === 0) return null;
 
-  const chronological = history
+  const recentChronological = history
+    .slice(0, 5)
     .map((item) => ({ item, stats: getWorkoutStats(item) }))
     .reverse();
-  const e1rmPoints = chronological
-    .map((entry) => entry.stats.e1rm)
-    .filter((value): value is number => value != null);
-  const volumePoints = chronological
-    .map((entry) => entry.stats.volume)
-    .filter((value): value is number => value != null);
-  const sparkline = e1rmPoints.length >= 2 ? e1rmPoints : volumePoints;
-  const bestEntry = chronological.reduce<ParsedWorkoutStats | null>(
+  const allChronological = history
+    .map((item) => ({ item, stats: getWorkoutStats(item) }))
+    .reverse();
+  const e1rmPoints = recentChronological.flatMap((entry, index) =>
+    entry.stats.e1rm == null
+      ? []
+      : [toHistoryChartPoint(entry, index, entry.stats.e1rm)],
+  );
+  const volumePoints = recentChronological.flatMap((entry, index) =>
+    entry.stats.volume == null
+      ? []
+      : [toHistoryChartPoint(entry, index, entry.stats.volume)],
+  );
+  const bestEntry = allChronological.reduce<ParsedWorkoutStats | null>(
     (best, entry) => {
       if (!best || entry.stats.bestSetScore > best.bestSetScore) {
         return entry.stats;
@@ -387,17 +442,22 @@ function buildHistoryStats(history: PreviousExercise[]): HistoryStats | null {
   );
 
   return {
-    count: history.length,
-    primaryLabel: e1rmPoints.length >= 2 ? "e1rm" : "load",
-    primaryTrend:
-      e1rmPoints.length >= 2
-        ? formatStatTrend(e1rmPoints, "lb")
-        : formatFallbackLoadTrend(chronological),
-    volumeTrend:
-      volumePoints.length >= 2 ? formatStatTrend(volumePoints, "lb") : "n/a",
+    chartCount: recentChronological.length,
+    e1rmPoints,
+    volumePoints,
     bestSet: bestEntry?.bestSet ?? "n/a",
-    frequency: formatFrequency(history),
-    sparkline,
+  };
+}
+
+function toHistoryChartPoint(
+  entry: { item: PreviousExercise; stats: ParsedWorkoutStats },
+  index: number,
+  value: number,
+): HistoryChartPoint {
+  return {
+    label: entry.item.date || entry.item.relation || `${index + 1}`,
+    value,
+    displayValue: `${formatStatNumber(value)}lb`,
   };
 }
 
@@ -451,52 +511,9 @@ function parseHistoryWeight(weight: string) {
   return numberMatch ? Number(numberMatch[0]) : null;
 }
 
-function formatStatTrend(values: number[], unit: string) {
-  const first = values[0]!;
-  const latest = values[values.length - 1]!;
-  const percent = first === 0 ? 0 : ((latest - first) / Math.abs(first)) * 100;
-  return `${formatStatNumber(first)}${unit} -> ${formatStatNumber(
-    latest,
-  )}${unit} · ${formatSignedPercent(percent)}`;
-}
-
-function formatFallbackLoadTrend(
-  chronological: Array<{ item: PreviousExercise; stats: ParsedWorkoutStats }>,
-) {
-  const bestLoads = chronological
-    .map((entry) =>
-      Math.max(
-        ...entry.item.workingSets
-          .map((set) => parseHistoryWeight(set.weight))
-          .filter((weight): weight is number => weight != null),
-      ),
-    )
-    .filter((weight) => Number.isFinite(weight));
-
-  if (bestLoads.length >= 2) return formatStatTrend(bestLoads, "lb");
-  if (bestLoads.length === 1) return `${formatStatNumber(bestLoads[0]!)}lb`;
-  return "n/a";
-}
-
-function formatFrequency(history: PreviousExercise[]) {
-  const oldest = history[history.length - 1];
-  if (!oldest?.relativeDate) return `${history.length} times`;
-  return `${history.length} times · since ${oldest.relativeDate}`;
-}
-
-function formatSignedPercent(value: number) {
-  const rounded = Math.round(value);
-  if (rounded === 0) return "same";
-  return `${rounded > 0 ? "+" : ""}${rounded}%`;
-}
-
 function formatStatNumber(value: number) {
   const rounded = Number(value.toFixed(1));
   return Number.isInteger(rounded)
     ? rounded.toLocaleString()
     : rounded.toLocaleString(undefined, { maximumFractionDigits: 1 });
-}
-
-function roundSvgPoint(value: number) {
-  return Number(value.toFixed(2));
 }

--- a/apps/web/src/components/workout-reference/workout_history.tsx
+++ b/apps/web/src/components/workout-reference/workout_history.tsx
@@ -125,6 +125,7 @@ type HistoryStats = {
 
 type HistoryChartPoint = {
   label: string;
+  xValue: number;
   value: number;
   displayValue: string;
 };
@@ -192,7 +193,12 @@ function HistoryTinyChart({
             data={points}
             margin={{ top: 18, right: 14, bottom: 2, left: 14 }}
           >
-            <XAxis dataKey="label" hide />
+            <XAxis
+              dataKey="xValue"
+              type="number"
+              hide
+              domain={getChartXDomain(points)}
+            />
             <YAxis hide domain={getChartDomain(points)} />
             <Line
               dataKey="value"
@@ -238,6 +244,17 @@ function getChartDomain(points: HistoryChartPoint[]) {
 
   const padding = (max - min) * 0.2;
   return [Math.max(0, min - padding), max + padding];
+}
+
+function getChartXDomain(points: HistoryChartPoint[]) {
+  const values = points.map((point) => point.xValue);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+
+  if (min === max) return [min - 1, max + 1];
+
+  const padding = Math.max(1, (max - min) * 0.04);
+  return [min - padding, max + padding];
 }
 
 function HistoryItem({
@@ -418,18 +435,28 @@ function buildHistoryStats(history: PreviousExercise[]): HistoryStats | null {
     .slice(0, 5)
     .map((item) => ({ item, stats: getWorkoutStats(item) }))
     .reverse();
+  const recentChartXValues = getHistoryChartXValues(
+    recentChronological.map((entry) => entry.item),
+  );
   const allChronological = history
     .map((item) => ({ item, stats: getWorkoutStats(item) }))
     .reverse();
   const e1rmPoints = recentChronological.flatMap((entry, index) =>
     entry.stats.e1rm == null
       ? []
-      : [toHistoryChartPoint(entry, index, entry.stats.e1rm)],
+      : [toHistoryChartPoint(entry, index, recentChartXValues, entry.stats.e1rm)],
   );
   const volumePoints = recentChronological.flatMap((entry, index) =>
     entry.stats.volume == null
       ? []
-      : [toHistoryChartPoint(entry, index, entry.stats.volume)],
+      : [
+          toHistoryChartPoint(
+            entry,
+            index,
+            recentChartXValues,
+            entry.stats.volume,
+          ),
+        ],
   );
   const bestEntry = allChronological.reduce<ParsedWorkoutStats | null>(
     (best, entry) => {
@@ -452,13 +479,50 @@ function buildHistoryStats(history: PreviousExercise[]): HistoryStats | null {
 function toHistoryChartPoint(
   entry: { item: PreviousExercise; stats: ParsedWorkoutStats },
   index: number,
+  xValues: number[],
   value: number,
 ): HistoryChartPoint {
   return {
     label: entry.item.date || entry.item.relation || `${index + 1}`,
+    xValue: xValues[index] ?? index,
     value,
     displayValue: `${formatStatNumber(value)}lb`,
   };
+}
+
+function getHistoryChartXValues(history: PreviousExercise[]) {
+  const daysAgoValues = history.map((item) =>
+    parseHistoryRelativeDaysAgo(item.relativeDate),
+  );
+
+  if (
+    daysAgoValues.every((value): value is number => value != null) &&
+    new Set(daysAgoValues).size > 1
+  ) {
+    const oldestDaysAgo = Math.max(...daysAgoValues);
+    return daysAgoValues.map((daysAgo) => oldestDaysAgo - daysAgo);
+  }
+
+  return history.map((_, index) => index);
+}
+
+function parseHistoryRelativeDaysAgo(relativeDate: string) {
+  const normalized = relativeDate.trim().toLowerCase();
+  if (normalized === "today") return 0;
+  if (normalized === "yesterday") return 1;
+
+  const match = /^(\d+)\s+(day|week|month|year)s?\s+ago$/.exec(normalized);
+  if (!match) return null;
+
+  const value = Number(match[1]);
+  const unit = match[2];
+  if (!Number.isFinite(value)) return null;
+
+  if (unit === "day") return value;
+  if (unit === "week") return value * 7;
+  if (unit === "month") return value * 30;
+  if (unit === "year") return value * 365;
+  return null;
 }
 
 function getWorkoutStats(item: PreviousExercise): ParsedWorkoutStats {
@@ -468,7 +532,7 @@ function getWorkoutStats(item: PreviousExercise): ParsedWorkoutStats {
   let volume = 0;
 
   for (const set of item.workingSets) {
-    const weight = parseHistoryWeight(set.weight);
+    const weight = parseHistoryWeight(set.weight, item.bodyWeightLb);
     const reps = set.reps
       .map((rep) => Number(rep))
       .filter((rep) => Number.isFinite(rep) && rep > 0);
@@ -500,12 +564,15 @@ function getWorkoutStats(item: PreviousExercise): ParsedWorkoutStats {
   };
 }
 
-function parseHistoryWeight(weight: string) {
+function parseHistoryWeight(weight: string, bodyWeightLb?: number | null) {
   const compact = weight.replace(/\s+/g, "");
-  if (compact === "BW") return 0;
+  if (compact === "BW") return bodyWeightLb ?? 0;
 
   const bodyweightMatch = /^BW([+-]\d+(?:\.\d+)?)lb?$/i.exec(compact);
-  if (bodyweightMatch?.[1]) return Number(bodyweightMatch[1]);
+  if (bodyweightMatch?.[1]) {
+    const offset = Number(bodyweightMatch[1]);
+    return bodyWeightLb == null ? offset : bodyWeightLb + offset;
+  }
 
   const numberMatch = /-?\d+(?:\.\d+)?/.exec(compact);
   return numberMatch ? Number(numberMatch[0]) : null;

--- a/apps/web/src/components/workout-reference/workout_history.tsx
+++ b/apps/web/src/components/workout-reference/workout_history.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type {
   ExerciseSet,
   PreviousExercise,
@@ -13,6 +13,7 @@ import {
   TimelineFootnoteMarker,
   TimelineFootnoteRef,
 } from "@/components/workout-reference/timeline_notes";
+import { estimate1RM } from "@lift-prog/workout-core";
 
 export function HistoryDisclosure({
   expanded,
@@ -33,14 +34,24 @@ export function HistoryViewport({ history }: { history: PreviousExercise[] }) {
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const itemRefs = useRef<Array<HTMLElement | null>>([]);
   const scrollEndTimeoutRef = useRef<number | null>(null);
-  const [activeIndex, setActiveIndex] = useState(0);
+  const stats = useMemo(() => buildHistoryStats(history), [history]);
+  const initialIndex = stats ? 1 : 0;
+  const itemCount = history.length + (stats ? 1 : 0);
+  const [activeIndex, setActiveIndex] = useState(initialIndex);
   const [activeHeight, setActiveHeight] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    setActiveIndex(initialIndex);
+    const scrollNode = viewportRef.current;
+    if (!scrollNode) return;
+    scrollNode.scrollLeft = scrollNode.clientWidth * initialIndex;
+  }, [initialIndex, history]);
 
   useLayoutEffect(() => {
     const activeItem = itemRefs.current[activeIndex];
     if (!activeItem) return;
     setActiveHeight(Math.ceil(activeItem.getBoundingClientRect().height));
-  }, [activeIndex, history]);
+  }, [activeIndex, history, stats]);
 
   useEffect(() => {
     return () => {
@@ -64,7 +75,7 @@ export function HistoryViewport({ history }: { history: PreviousExercise[] }) {
       if (!width) return;
       setActiveIndex(
         Math.min(
-          history.length - 1,
+          itemCount - 1,
           Math.max(0, Math.round(scrollNode.scrollLeft / width)),
         ),
       );
@@ -79,16 +90,105 @@ export function HistoryViewport({ history }: { history: PreviousExercise[] }) {
       style={activeHeight == null ? undefined : { height: activeHeight }}
       onScroll={handleScroll}
     >
+      {stats ? (
+        <HistoryStatsItem
+          stats={stats}
+          refCallback={(node) => {
+            itemRefs.current[0] = node;
+          }}
+        />
+      ) : null}
       {history.map((item, index) => (
         <HistoryItem
           key={`${item.relation}-${item.date}`}
           item={item}
           refCallback={(node) => {
-            itemRefs.current[index] = node;
+            itemRefs.current[index + (stats ? 1 : 0)] = node;
           }}
         />
       ))}
     </div>
+  );
+}
+
+type HistoryStats = {
+  count: number;
+  primaryLabel: string;
+  primaryTrend: string;
+  volumeTrend: string;
+  bestSet: string;
+  frequency: string;
+  sparkline: number[];
+};
+
+function HistoryStatsItem({
+  stats,
+  refCallback,
+}: {
+  stats: HistoryStats;
+  refCallback?: (node: HTMLElement | null) => void;
+}) {
+  return (
+    <article
+      ref={refCallback}
+      className="flex min-w-full snap-start flex-col gap-1 pr-1 text-[12px] leading-4"
+    >
+      <p className="text-[12px] leading-4 text-[#716b5d]">
+        stats · {stats.count} workouts
+      </p>
+      <MiniSparkline values={stats.sparkline} />
+      <div className="grid gap-0.5">
+        <StatsLine label={stats.primaryLabel} value={stats.primaryTrend} />
+        <StatsLine label="best" value={stats.bestSet} />
+        <StatsLine label="volume" value={stats.volumeTrend} />
+        <StatsLine label="seen" value={stats.frequency} />
+      </div>
+    </article>
+  );
+}
+
+function StatsLine({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[4.5rem_1fr] gap-1">
+      <span className="text-[#8a8373]">{label}</span>
+      <span className="text-[#17150f]">{value}</span>
+    </div>
+  );
+}
+
+function MiniSparkline({ values }: { values: number[] }) {
+  if (values.length < 2) {
+    return <div className="h-6 text-[11px] text-[#8a8373]">more data soon</div>;
+  }
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const width = 160;
+  const height = 24;
+  const points = values
+    .map((value, index) => {
+      const x = values.length === 1 ? 0 : (index / (values.length - 1)) * width;
+      const y = height - ((value - min) / range) * (height - 4) - 2;
+      return `${roundSvgPoint(x)},${roundSvgPoint(y)}`;
+    })
+    .join(" ");
+
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-6 w-full overflow-visible"
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="#a79b83"
+        strokeWidth="1.5"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
   );
 }
 
@@ -118,9 +218,7 @@ function HistoryMeta({ item }: { item: PreviousExercise }) {
   const parts = [item.relation, item.relativeDate, item.date].filter(Boolean);
 
   return (
-    <p className="text-[12px] leading-4 text-[#716b5d]">
-      {parts.join(" · ")}
-    </p>
+    <p className="text-[12px] leading-4 text-[#716b5d]">{parts.join(" · ")}</p>
   );
 }
 
@@ -256,4 +354,149 @@ function formatCompactHistoryWeight(weight: string) {
 
 function isShortBreak(restBefore: string | undefined) {
   return restBefore === "short";
+}
+
+type ParsedWorkoutStats = {
+  e1rm: number | null;
+  volume: number | null;
+  bestSet: string | null;
+  bestSetScore: number;
+};
+
+function buildHistoryStats(history: PreviousExercise[]): HistoryStats | null {
+  if (history.length === 0) return null;
+
+  const chronological = history
+    .map((item) => ({ item, stats: getWorkoutStats(item) }))
+    .reverse();
+  const e1rmPoints = chronological
+    .map((entry) => entry.stats.e1rm)
+    .filter((value): value is number => value != null);
+  const volumePoints = chronological
+    .map((entry) => entry.stats.volume)
+    .filter((value): value is number => value != null);
+  const sparkline = e1rmPoints.length >= 2 ? e1rmPoints : volumePoints;
+  const bestEntry = chronological.reduce<ParsedWorkoutStats | null>(
+    (best, entry) => {
+      if (!best || entry.stats.bestSetScore > best.bestSetScore) {
+        return entry.stats;
+      }
+      return best;
+    },
+    null,
+  );
+
+  return {
+    count: history.length,
+    primaryLabel: e1rmPoints.length >= 2 ? "e1rm" : "load",
+    primaryTrend:
+      e1rmPoints.length >= 2
+        ? formatStatTrend(e1rmPoints, "lb")
+        : formatFallbackLoadTrend(chronological),
+    volumeTrend:
+      volumePoints.length >= 2 ? formatStatTrend(volumePoints, "lb") : "n/a",
+    bestSet: bestEntry?.bestSet ?? "n/a",
+    frequency: formatFrequency(history),
+    sparkline,
+  };
+}
+
+function getWorkoutStats(item: PreviousExercise): ParsedWorkoutStats {
+  let bestSet: string | null = null;
+  let bestSetScore = Number.NEGATIVE_INFINITY;
+  let bestE1rm: number | null = null;
+  let volume = 0;
+
+  for (const set of item.workingSets) {
+    const weight = parseHistoryWeight(set.weight);
+    const reps = set.reps
+      .map((rep) => Number(rep))
+      .filter((rep) => Number.isFinite(rep) && rep > 0);
+    if (weight == null || reps.length === 0) continue;
+
+    const repTotal = reps.reduce((sum, rep) => sum + rep, 0);
+    if (weight > 0) {
+      volume += weight * repTotal;
+    }
+
+    for (const rep of reps) {
+      const e1rm = weight > 0 ? estimate1RM(weight, rep) : null;
+      const score = e1rm ?? weight;
+      if (e1rm != null && (bestE1rm == null || e1rm > bestE1rm)) {
+        bestE1rm = e1rm;
+      }
+      if (score > bestSetScore) {
+        bestSetScore = score;
+        bestSet = `${formatStatNumber(weight)}lb×${formatStatNumber(rep)}`;
+      }
+    }
+  }
+
+  return {
+    e1rm: bestE1rm,
+    volume: volume > 0 ? volume : null,
+    bestSet,
+    bestSetScore,
+  };
+}
+
+function parseHistoryWeight(weight: string) {
+  const compact = weight.replace(/\s+/g, "");
+  if (compact === "BW") return 0;
+
+  const bodyweightMatch = /^BW([+-]\d+(?:\.\d+)?)lb?$/i.exec(compact);
+  if (bodyweightMatch?.[1]) return Number(bodyweightMatch[1]);
+
+  const numberMatch = /-?\d+(?:\.\d+)?/.exec(compact);
+  return numberMatch ? Number(numberMatch[0]) : null;
+}
+
+function formatStatTrend(values: number[], unit: string) {
+  const first = values[0]!;
+  const latest = values[values.length - 1]!;
+  const percent = first === 0 ? 0 : ((latest - first) / Math.abs(first)) * 100;
+  return `${formatStatNumber(first)}${unit} -> ${formatStatNumber(
+    latest,
+  )}${unit} · ${formatSignedPercent(percent)}`;
+}
+
+function formatFallbackLoadTrend(
+  chronological: Array<{ item: PreviousExercise; stats: ParsedWorkoutStats }>,
+) {
+  const bestLoads = chronological
+    .map((entry) =>
+      Math.max(
+        ...entry.item.workingSets
+          .map((set) => parseHistoryWeight(set.weight))
+          .filter((weight): weight is number => weight != null),
+      ),
+    )
+    .filter((weight) => Number.isFinite(weight));
+
+  if (bestLoads.length >= 2) return formatStatTrend(bestLoads, "lb");
+  if (bestLoads.length === 1) return `${formatStatNumber(bestLoads[0]!)}lb`;
+  return "n/a";
+}
+
+function formatFrequency(history: PreviousExercise[]) {
+  const oldest = history[history.length - 1];
+  if (!oldest?.relativeDate) return `${history.length} times`;
+  return `${history.length} times · since ${oldest.relativeDate}`;
+}
+
+function formatSignedPercent(value: number) {
+  const rounded = Math.round(value);
+  if (rounded === 0) return "same";
+  return `${rounded > 0 ? "+" : ""}${rounded}%`;
+}
+
+function formatStatNumber(value: number) {
+  const rounded = Number(value.toFixed(1));
+  return Number.isInteger(rounded)
+    ? rounded.toLocaleString()
+    : rounded.toLocaleString(undefined, { maximumFractionDigits: 1 });
+}
+
+function roundSvgPoint(value: number) {
+  return Number(value.toFixed(2));
 }

--- a/apps/web/src/components/workout-reference/workout_reference_sandbox.tsx
+++ b/apps/web/src/components/workout-reference/workout_reference_sandbox.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { PreviousWorkoutExercise } from "@/components/workout-reference/previous-workout-exercise";
 import type { PlateSettings } from "@/components/workout-reference/weight_helper_dialog";
+import { WorkoutHeader } from "@/components/workout/workout_header";
 import type {
   CurrentExerciseSet,
   PreviousExercise,
@@ -148,6 +149,10 @@ const sampleCurrentSets: CurrentExerciseSet[] = [
   },
 ];
 
+function noopSandboxAction() {
+  return undefined;
+}
+
 export function PreviousWorkoutExerciseSandbox() {
   const [plateSettings, setPlateSettings] = useState<PlateSettings>({
     startingWeight: 0,
@@ -189,6 +194,7 @@ export function PreviousWorkoutExerciseSandbox() {
 
   return (
     <div className="select-none">
+      <WorkoutBodyWeightSandbox />
       <PreviousWorkoutExercise
         exerciseName="Pull-ups"
         exerciseNote="Hold dumbbell in thighs"
@@ -197,6 +203,40 @@ export function PreviousWorkoutExerciseSandbox() {
         history={sampleHistory}
         initialCurrentSets={sampleCurrentSets}
         onPlateSettingsChange={setPlateSettings}
+      />
+    </div>
+  );
+}
+
+function WorkoutBodyWeightSandbox() {
+  const [bodyWeightLb, setBodyWeightLb] = useState<number | null>(null);
+  const [workoutName, setWorkoutName] = useState("Pull day");
+  const [isEditingName, setIsEditingName] = useState(false);
+  const startTime = new Date("2026-06-19T09:00:00").getTime();
+
+  return (
+    <div className="mx-auto mb-5 w-full max-w-[430px] px-3 pt-4">
+      <WorkoutHeader
+        name={workoutName}
+        startTime={startTime}
+        completedAt={new Date(startTime + 45 * 60_000)}
+        bodyWeightLb={bodyWeightLb}
+        showBodyWeight
+        editableName={workoutName}
+        isEditingName={isEditingName}
+        workoutNote=""
+        showFinishAction={false}
+        canUndo={false}
+        canRedo={false}
+        onStartTimeChange={noopSandboxAction}
+        onBodyWeightChange={setBodyWeightLb}
+        onCompletedAtChange={noopSandboxAction}
+        onEditableNameChange={setWorkoutName}
+        onStartEditingName={() => setIsEditingName(true)}
+        onCancelEditingName={() => setIsEditingName(false)}
+        onSaveName={() => setIsEditingName(false)}
+        onEditWorkoutNote={noopSandboxAction}
+        onFinishWorkout={noopSandboxAction}
       />
     </div>
   );

--- a/apps/web/src/components/workout-reference/workout_reference_types.ts
+++ b/apps/web/src/components/workout-reference/workout_reference_types.ts
@@ -16,6 +16,7 @@ export type PreviousExercise = {
   relation: string;
   relativeDate: string;
   date: string;
+  bodyWeightLb?: number | null;
   workoutNote?: string;
   workoutExerciseNote?: string;
   exerciseNoteChanged?: boolean;

--- a/apps/web/src/components/workout/workout.tsx
+++ b/apps/web/src/components/workout/workout.tsx
@@ -59,6 +59,7 @@ type WorkoutProps = {
   autoRestore?: boolean;
   startTime?: number;
   completedAt?: Date;
+  bodyWeightLb?: number | null;
   workoutNote?: string;
   contextLabel?: string;
   persistDraft?: boolean;
@@ -291,6 +292,7 @@ function WorkoutComponentInner({
   autoRestore = false,
   startTime = Date.now(),
   completedAt,
+  bodyWeightLb,
   workoutNote = "",
   contextLabel,
   persistDraft = true,
@@ -317,6 +319,7 @@ function WorkoutComponentInner({
     notes: workoutNote.trim() ? [{ text: workoutNote.trim() }] : [],
     startTime,
     name: workoutName || "Workout",
+    bodyWeightLb: bodyWeightLb ?? null,
     isInProgress: true,
     activeField: { exerciseIndex: null, setIndex: null, field: null },
     inputValue: "",
@@ -379,6 +382,13 @@ function WorkoutComponentInner({
       type: "SET_TIME_RANGE",
       startTime: nextStartTime,
       completedAt: new Date(nextStartTime + Math.max(60_000, durationMs)),
+    });
+  };
+
+  const handleBodyWeightChange = (nextBodyWeightLb: number | null) => {
+    dispatch({
+      type: "UPDATE_BODY_WEIGHT",
+      bodyWeightLb: nextBodyWeightLb,
     });
   };
 
@@ -732,6 +742,8 @@ function WorkoutComponentInner({
         name={state.name}
         startTime={state.startTime}
         completedAt={workoutCompletedAt}
+        bodyWeightLb={state.bodyWeightLb ?? null}
+        showBodyWeight={shouldShowBodyWeight(state, Boolean(workoutId))}
         contextLabel={contextLabel}
         editableName={editableName}
         isEditingName={isEditingName}
@@ -745,6 +757,7 @@ function WorkoutComponentInner({
         }
         canRedo={draftSession.future.length > 0}
         onStartTimeChange={handleStartTimeChange}
+        onBodyWeightChange={handleBodyWeightChange}
         onCompletedAtChange={(nextCompletedAt) =>
           dispatchDraft({
             type: "SET_COMPLETED_AT",
@@ -864,4 +877,22 @@ function WorkoutComponentInner({
       />
     </div>
   );
+}
+
+function shouldShowBodyWeight(workout: Workout, isSavedWorkout: boolean) {
+  if (isSavedWorkout && workout.bodyWeightLb != null) return true;
+
+  return workout.exercises.some((exercise) => {
+    const hasCurrentBodyweight = exercise.sets.some(
+      (set) => set.weightModifier === "bodyweight",
+    );
+    const hasPreviousBodyweight = exercise.previousSets.some(
+      (set) => set.weightModifier === "bodyweight",
+    );
+    const hasHistoryBodyweight = exercise.history?.some((entry) =>
+      entry.sets.some((set) => set.weightModifier === "bodyweight"),
+    );
+
+    return hasCurrentBodyweight || hasPreviousBodyweight || hasHistoryBodyweight;
+  });
 }

--- a/apps/web/src/components/workout/workout_header.tsx
+++ b/apps/web/src/components/workout/workout_header.tsx
@@ -16,6 +16,8 @@ export function WorkoutHeader({
   name,
   startTime,
   completedAt,
+  bodyWeightLb,
+  showBodyWeight = false,
   contextLabel,
   editableName,
   isEditingName,
@@ -27,6 +29,7 @@ export function WorkoutHeader({
   canUndo = false,
   canRedo = false,
   onStartTimeChange,
+  onBodyWeightChange,
   onCompletedAtChange,
   onEditableNameChange,
   onStartEditingName,
@@ -42,6 +45,8 @@ export function WorkoutHeader({
   name: string;
   startTime: number;
   completedAt: Date;
+  bodyWeightLb?: number | null;
+  showBodyWeight?: boolean;
   contextLabel?: string;
   editableName: string;
   isEditingName: boolean;
@@ -53,6 +58,7 @@ export function WorkoutHeader({
   canUndo?: boolean;
   canRedo?: boolean;
   onStartTimeChange: (startTime: number) => void;
+  onBodyWeightChange: (bodyWeightLb: number | null) => void;
   onCompletedAtChange: (completedAt: Date) => void;
   onEditableNameChange: (name: string) => void;
   onStartEditingName: () => void;
@@ -66,6 +72,8 @@ export function WorkoutHeader({
   onRedo?: () => void;
 }) {
   const [editingTimePart, setEditingTimePart] = useState<TimeEditorPart>(null);
+  const [bodyWeightEditorOpen, setBodyWeightEditorOpen] = useState(false);
+  const [bodyWeightInput, setBodyWeightInput] = useState("");
   const [now, setNow] = useState(() => new Date());
   const startDate = new Date(startTime);
   const displayEnd = isInProgress ? now : completedAt;
@@ -78,6 +86,17 @@ export function WorkoutHeader({
     const interval = window.setInterval(() => setNow(new Date()), 1000);
     return () => window.clearInterval(interval);
   }, [isInProgress]);
+
+  function openBodyWeightEditor() {
+    setBodyWeightInput(bodyWeightLb == null ? "" : formatBodyWeight(bodyWeightLb));
+    setBodyWeightEditorOpen(true);
+  }
+
+  function saveBodyWeight() {
+    const nextValue = parseBodyWeightInput(bodyWeightInput);
+    onBodyWeightChange(nextValue);
+    setBodyWeightEditorOpen(false);
+  }
 
   return (
     <>
@@ -206,6 +225,18 @@ export function WorkoutHeader({
             </>
           )}
         </div>
+        {showBodyWeight ? (
+          <div className="mt-0.5 flex w-full min-w-0 flex-wrap items-baseline font-mono text-[11px] leading-4 text-[#716b5d]">
+            <span>bw</span>
+            <span className="px-1">·</span>
+            <TimeTextButton
+              ariaLabel="Edit body weight"
+              onClick={openBodyWeightEditor}
+            >
+              {bodyWeightLb == null ? "set" : `${formatBodyWeight(bodyWeightLb)}lb`}
+            </TimeTextButton>
+          </div>
+        ) : null}
         {workoutNote ? (
           <div className="mt-1 inline-flex max-w-full rounded-[4px] bg-[#eee8da] px-1.5 py-0.5 text-[12px] leading-4 text-[#433e33]">
             {workoutNote}
@@ -222,6 +253,18 @@ export function WorkoutHeader({
         onOpenChange={(open) => {
           if (!open) setEditingTimePart(null);
         }}
+      />
+      <BodyWeightEditor
+        open={bodyWeightEditorOpen}
+        value={bodyWeightInput}
+        onValueChange={setBodyWeightInput}
+        onSave={saveBodyWeight}
+        onClear={() => {
+          onBodyWeightChange(null);
+          setBodyWeightInput("");
+          setBodyWeightEditorOpen(false);
+        }}
+        onOpenChange={(open) => setBodyWeightEditorOpen(open)}
       />
     </>
   );
@@ -370,6 +413,62 @@ function WorkoutTimePartEditor({
   );
 }
 
+function BodyWeightEditor({
+  open,
+  value,
+  onValueChange,
+  onSave,
+  onClear,
+  onOpenChange,
+}: {
+  open: boolean;
+  value: string;
+  onValueChange: (value: string) => void;
+  onSave: () => void;
+  onClear: () => void;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {open ? (
+        <WorkoutEditorContent>
+          <DialogTitle className="sr-only">Edit body weight</DialogTitle>
+          <DialogDescription className="sr-only">
+            Set an approximate body weight for this workout.
+          </DialogDescription>
+          <WorkoutEditorLabel>body weight</WorkoutEditorLabel>
+          <div className="flex items-baseline gap-1">
+            <Input
+              autoFocus
+              aria-label="Body weight"
+              type="number"
+              min={1}
+              step="0.1"
+              inputMode="decimal"
+              value={value}
+              onChange={(event) => onValueChange(event.target.value)}
+              className="h-9 rounded-[4px] border-[#d7cfbc] bg-[#fdfcf8] font-mono text-[16px] text-[#17150f] shadow-none focus-visible:ring-[#a79b83]"
+            />
+            <span className="text-[12px] text-[#716b5d]">lb</span>
+          </div>
+          <div className="flex gap-1">
+            <button
+              type="button"
+              className="inline-flex h-9 items-center justify-center rounded-[4px] border border-[#d7cfbc] bg-[#fdfcf8] px-3 font-mono text-[12px] text-[#817a69] hover:bg-[#eee8da]"
+              onClick={onClear}
+            >
+              clear
+            </button>
+            <WorkoutEditorPrimaryAction onClick={onSave}>
+              done
+            </WorkoutEditorPrimaryAction>
+          </div>
+        </WorkoutEditorContent>
+      ) : null}
+    </Dialog>
+  );
+}
+
 function formatStartDate(date: Date) {
   return date
     .toLocaleDateString(undefined, {
@@ -423,6 +522,17 @@ function formatDurationMinutes(minutes: number) {
   return remainingMinutes === 0
     ? `${hours}h`
     : `${hours}h ${remainingMinutes}m`;
+}
+
+function parseBodyWeightInput(value: string) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return Number(parsed.toFixed(1));
+}
+
+function formatBodyWeight(value: number) {
+  const rounded = Number(value.toFixed(1));
+  return Number.isInteger(rounded) ? String(rounded) : String(rounded);
 }
 
 function formatDateInputValue(date: Date) {

--- a/apps/web/src/components/workout/workout_reference_adapters.ts
+++ b/apps/web/src/components/workout/workout_reference_adapters.ts
@@ -95,6 +95,7 @@ export function buildReferenceHistory(
       relation: entry.relation,
       relativeDate: entry.relativeDate,
       date: entry.date,
+      ...(entry.bodyWeightLb != null ? { bodyWeightLb: entry.bodyWeightLb } : {}),
       ...(entry.workoutNote ? { workoutNote: entry.workoutNote } : {}),
       ...(entry.workoutExerciseNote
         ? { workoutExerciseNote: entry.workoutExerciseNote }

--- a/apps/web/src/server/api/routers/workout.ts
+++ b/apps/web/src/server/api/routers/workout.ts
@@ -15,6 +15,7 @@ import {
 import {
   buildInitialExercisesForNames,
   buildInitialExercisesFromWorkout,
+  getLatestWorkoutBodyWeightLb,
 } from "@/server/services/workout-initializer";
 
 type WorkoutPrisma = Pick<PrismaClient, "exercise" | "userExercise">;
@@ -161,7 +162,8 @@ export const workoutRouter = createTRPCRouter({
   saveWorkout: protectedProcedure
     .input(CompletedWorkoutSchema)
     .mutation(async ({ ctx, input }) => {
-      const { name, exercises, notes, completedAt, startedAt } = input;
+      const { name, exercises, notes, completedAt, startedAt, bodyWeightLb } =
+        input;
       const prisma = ctx.db; // Use prisma client from context
       const userId = ctx.session.userId;
 
@@ -197,6 +199,7 @@ export const workoutRouter = createTRPCRouter({
             notes: notes,
             completedAt: completedAt,
             startedAt: startedAt,
+            bodyWeightLb: bodyWeightLb ?? null,
           },
         });
 
@@ -292,7 +295,14 @@ export const workoutRouter = createTRPCRouter({
         });
       }
 
-      const { name, exercises, notes, completedAt, startedAt } = input.workout;
+      const {
+        name,
+        exercises,
+        notes,
+        completedAt,
+        startedAt,
+        bodyWeightLb,
+      } = input.workout;
 
       return prisma.$transaction(async (tx) => {
         const userExerciseIdByName = await resolveUserExerciseIds({
@@ -308,6 +318,7 @@ export const workoutRouter = createTRPCRouter({
             notes,
             startedAt,
             completedAt,
+            bodyWeightLb: bodyWeightLb ?? null,
           },
         });
 
@@ -395,6 +406,7 @@ export const workoutRouter = createTRPCRouter({
           name: true,
           completedAt: true,
           startedAt: true, // Add startedAt to calculate duration
+          bodyWeightLb: true,
           workoutExercises: {
             orderBy: { order: "asc" },
             select: {
@@ -439,6 +451,7 @@ export const workoutRouter = createTRPCRouter({
           name: workout.name,
           completedAt: workout.completedAt,
           startedAt: workout.startedAt,
+          bodyWeightLb: workout.bodyWeightLb,
           exerciseSummaries: summaries,
         };
       });
@@ -483,6 +496,10 @@ export const workoutRouter = createTRPCRouter({
       }
 
       if (input.mode === "exerciseList") {
+        const bodyWeightLb = await getLatestWorkoutBodyWeightLb({
+          prisma: ctx.db,
+          userId,
+        });
         const exercises = await buildInitialExercisesForNames({
           prisma: ctx.db,
           userId,
@@ -491,17 +508,29 @@ export const workoutRouter = createTRPCRouter({
 
         return {
           workoutName: input.workoutName ?? "Workout",
+          bodyWeightLb,
           exercises,
         };
       }
 
       try {
-        return await buildInitialExercisesFromWorkout({
-          prisma: ctx.db,
-          userId,
-          workoutId: input.workoutId,
-          options: { preserveInstanceNotes: false },
-        });
+        const [workout, bodyWeightLb] = await Promise.all([
+          buildInitialExercisesFromWorkout({
+            prisma: ctx.db,
+            userId,
+            workoutId: input.workoutId,
+            options: { preserveInstanceNotes: false },
+          }),
+          getLatestWorkoutBodyWeightLb({
+            prisma: ctx.db,
+            userId,
+          }),
+        ]);
+
+        return {
+          ...workout,
+          bodyWeightLb: bodyWeightLb ?? workout.bodyWeightLb,
+        };
       } catch (error) {
         throw new TRPCError({
           code: "NOT_FOUND",

--- a/apps/web/src/server/services/workout-initializer.ts
+++ b/apps/web/src/server/services/workout-initializer.ts
@@ -58,6 +58,7 @@ type WorkoutExerciseHistoryRecord = {
   exerciseNotesSnapshot: string | null;
   workout: {
     completedAt: Date | null;
+    bodyWeightLb: number | null;
     notes: string | null;
   };
   sets: Array<{
@@ -119,6 +120,9 @@ function mapHistory(
         relation: historyRelation(index),
         relativeDate: formatRelativeDate(record.workout.completedAt),
         date: formatShortDate(record.workout.completedAt),
+        ...(record.workout.bodyWeightLb != null
+          ? { bodyWeightLb: record.workout.bodyWeightLb }
+          : {}),
         ...(record.workout.notes ? { workoutNote: record.workout.notes } : {}),
         ...(record.notes ? { workoutExerciseNote: record.notes } : {}),
         ...(record.exerciseNotesSnapshot
@@ -165,6 +169,7 @@ async function getHistoriesByUserExerciseId({
       workout: {
         select: {
           completedAt: true,
+          bodyWeightLb: true,
           notes: true,
         },
       },
@@ -343,6 +348,7 @@ export async function buildInitialExercisesFromWorkout({
   exercises: PreviousExerciseData[];
   startedAt: Date;
   completedAt: Date | null;
+  bodyWeightLb: number | null;
   notes: string | null;
 }> {
   const workout = await prisma.workout.findFirst({
@@ -372,6 +378,7 @@ export async function buildInitialExercisesFromWorkout({
               reps: true,
               modifier: true,
               weightModifier: true,
+              completed: true,
               restBefore: true,
               notes: true,
               rir: true,
@@ -451,6 +458,26 @@ export async function buildInitialExercisesFromWorkout({
     exercises,
     startedAt: workout.startedAt,
     completedAt: workout.completedAt,
+    bodyWeightLb: workout.bodyWeightLb,
     notes: workout.notes,
   };
+}
+
+export async function getLatestWorkoutBodyWeightLb({
+  prisma,
+  userId,
+}: {
+  prisma: PrismaClient;
+  userId: string;
+}) {
+  const workout = await prisma.workout.findFirst({
+    where: {
+      userId,
+      bodyWeightLb: { not: null },
+    },
+    orderBy: [{ startedAt: "desc" }, { id: "desc" }],
+    select: { bodyWeightLb: true },
+  });
+
+  return workout?.bodyWeightLb ?? null;
 }

--- a/apps/web/test/previousWorkoutExercise.test.tsx
+++ b/apps/web/test/previousWorkoutExercise.test.tsx
@@ -55,6 +55,9 @@ describe("PreviousWorkoutExercise", () => {
     expect(screen.getAllByText("working sets").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Foot assist").length).toBeGreaterThan(0);
     expect(screen.getAllByText("solid first set").length).toBeGreaterThan(0);
+    expect(screen.getByText("stats · 2 workouts")).toBeVisible();
+    expect(screen.getByText("23.2lb -> 30lb · +29%")).toBeVisible();
+    expect(screen.getByText("240lb -> 420lb · +75%")).toBeVisible();
 
     fireEvent.click(
       screen.getByRole("button", { name: "Hide exercise history" }),
@@ -129,9 +132,7 @@ describe("PreviousWorkoutExercise", () => {
         .getAllByRole("button", { name: "Delete set 1" })
         .find((button) => !button.hasAttribute("disabled"))!,
     );
-    fireEvent.click(
-      screen.getByRole("button", { name: /^Confirm Delete / }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /^Confirm Delete / }));
 
     expect(screen.queryByText("keep elbows tight")).toBeNull();
   });

--- a/apps/web/test/previousWorkoutExercise.test.tsx
+++ b/apps/web/test/previousWorkoutExercise.test.tsx
@@ -55,9 +55,15 @@ describe("PreviousWorkoutExercise", () => {
     expect(screen.getAllByText("working sets").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Foot assist").length).toBeGreaterThan(0);
     expect(screen.getAllByText("solid first set").length).toBeGreaterThan(0);
-    expect(screen.getByText("stats · 2 workouts")).toBeVisible();
-    expect(screen.getByText("23.2lb -> 30lb · +29%")).toBeVisible();
-    expect(screen.getByText("240lb -> 420lb · +75%")).toBeVisible();
+    expect(screen.getByText("stats · last 2 workouts")).toBeVisible();
+    expect(screen.getByText("expected 1rm")).toBeVisible();
+    expect(screen.getByText("volume")).toBeVisible();
+    expect(
+      screen.getByLabelText("expected 1rm: 23.2lb, 30lb"),
+    ).toBeVisible();
+    expect(screen.getByLabelText("volume: 240lb, 420lb")).toBeVisible();
+    expect(screen.getByText("best set")).toBeVisible();
+    expect(screen.queryByText("seen")).toBeNull();
 
     fireEvent.click(
       screen.getByRole("button", { name: "Hide exercise history" }),

--- a/apps/web/test/workout.integration.test.tsx
+++ b/apps/web/test/workout.integration.test.tsx
@@ -18,6 +18,7 @@ const trpcMocks = vi.hoisted(() => ({
   updateWorkoutMutate: vi.fn(),
   deleteWorkoutMutate: vi.fn(),
   updateNoteMutate: vi.fn(),
+  updatePlateDefaultsMutate: vi.fn(),
 }));
 
 vi.mock("@clerk/nextjs", () => ({
@@ -108,6 +109,15 @@ vi.mock("@/trpc/react", () => ({
           },
         }),
       },
+      updatePlateDefaults: {
+        useMutation: (opts?: any) => ({
+          isPending: false,
+          mutate: (payload: any) => {
+            trpcMocks.updatePlateDefaultsMutate(payload);
+            void opts?.onSuccess?.(null, payload, null);
+          },
+        }),
+      },
     },
   },
 }));
@@ -123,6 +133,7 @@ describe("WorkoutComponent", () => {
     trpcMocks.updateWorkoutMutate.mockReset();
     trpcMocks.deleteWorkoutMutate.mockReset();
     trpcMocks.updateNoteMutate.mockReset();
+    trpcMocks.updatePlateDefaultsMutate.mockReset();
     trpcMocks.prepareInitialWorkoutFetch.mockReset();
     trpcMocks.prepareInitialWorkoutFetch.mockImplementation(
       async ({ exerciseNames }) => ({
@@ -226,5 +237,44 @@ describe("WorkoutComponent", () => {
     );
     expect(screen.queryByRole("heading", { name: "pull-ups" })).toBeNull();
     expect(trpcMocks.addExerciseMutate).not.toHaveBeenCalled();
+  });
+
+  it("sets approximate body weight for bodyweight workouts", async () => {
+    render(
+      <WorkoutComponent
+        workoutName="Pull day"
+        exercises={[
+          {
+            name: "Pull-ups",
+            sets: [
+              {
+                weight: 0,
+                reps: 15,
+                modifier: "warmup",
+                weightModifier: "bodyweight",
+              },
+              { weight: 20, reps: 8, weightModifier: "bodyweight" },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Edit body weight" }));
+    fireEvent.change(await screen.findByRole("spinbutton", { name: "Body weight" }), {
+      target: { value: "195.5" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "done" }));
+
+    expect(await screen.findByText("195.5lb")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish workout" }));
+    fireEvent.click(await screen.findByRole("button", { name: "save workout" }));
+
+    await waitFor(() =>
+      expect(trpcMocks.saveWorkoutMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ bodyWeightLb: 195.5 }),
+      ),
+    );
   });
 });

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -3,6 +3,38 @@ import { vi } from "vitest";
 import { afterEach } from "vitest";
 import { cleanup } from "@testing-library/react";
 
+class ResizeObserverMock {
+  constructor(private callback: ResizeObserverCallback) {}
+
+  observe(target: Element) {
+    this.callback(
+      [
+        {
+          target,
+          contentRect: {
+            x: 0,
+            y: 0,
+            top: 0,
+            right: 320,
+            bottom: 48,
+            left: 0,
+            width: 320,
+            height: 48,
+            toJSON: () => ({}),
+          },
+        } as unknown as ResizeObserverEntry,
+      ],
+      this as unknown as ResizeObserver,
+    );
+  }
+
+  unobserve() {}
+  disconnect() {}
+}
+
+globalThis.ResizeObserver ??=
+  ResizeObserverMock as unknown as typeof ResizeObserver;
+
 // Mock the next/navigation hooks
 vi.mock("next/navigation", () => ({
   useRouter: () => ({

--- a/packages/workout-core/src/schemas/workout-schema.ts
+++ b/packages/workout-core/src/schemas/workout-schema.ts
@@ -31,6 +31,7 @@ export const CompletedWorkoutSchema = z.object({
   notes: z.string().optional(),
   completedAt: z.coerce.date(),
   startedAt: z.coerce.date(),
+  bodyWeightLb: z.number().positive().nullable().optional(),
   exercises: z.array(CompletedExerciseSchema),
 });
 

--- a/packages/workout-core/src/workout-logic.ts
+++ b/packages/workout-core/src/workout-logic.ts
@@ -58,6 +58,7 @@ export interface WorkoutExercise {
     relation: string;
     relativeDate: string;
     date: string;
+    bodyWeightLb?: number | null;
     workoutNote?: string | null;
     workoutExerciseNote?: string | null;
     exerciseNotesSnapshot?: string | null;
@@ -90,6 +91,7 @@ export interface Workout {
   notes: Note[];
   startTime: number; // Added startTime
   name: string; // Added workout name
+  bodyWeightLb?: number | null;
   isInProgress: boolean; // Added to track if workout is active
 }
 
@@ -783,6 +785,7 @@ export type Action =
   | { type: "DELETE_WORKOUT_NOTE"; noteIndex: number }
   | { type: "REORDER_WORKOUT_NOTES"; fromIndex: number; toIndex: number }
   | { type: "UPDATE_WORKOUT_NAME"; name: string }
+  | { type: "UPDATE_BODY_WEIGHT"; bodyWeightLb: number | null }
   | { type: "REPLACE_STATE"; state: Workout };
 
 // --------------------------- Reducer -----------------------------------
@@ -806,6 +809,11 @@ export const workoutReducer = (state: Workout, action: Action): Workout => {
       return {
         ...state,
         name: action.name,
+      };
+    case "UPDATE_BODY_WEIGHT":
+      return {
+        ...state,
+        bodyWeightLb: action.bodyWeightLb,
       };
     case "FOCUS_FIELD": {
       const { exerciseIndex, setIndex, field } = action;
@@ -1883,6 +1891,7 @@ export function finalizeWorkout(
     name: state.name,
     startedAt: new Date(state.startTime),
     completedAt: new Date(),
+    bodyWeightLb: state.bodyWeightLb ?? null,
     notes: workoutNotesText,
     exercises: completedExercises,
   };

--- a/packages/workout-sdk/src/contracts.ts
+++ b/packages/workout-sdk/src/contracts.ts
@@ -32,6 +32,7 @@ export const PrepareInitialWorkoutInputSchema = z.discriminatedUnion("mode", [
 
 export const PrepareInitialWorkoutResultSchema = z.object({
   workoutName: z.string(),
+  bodyWeightLb: z.number().positive().nullable().optional(),
   exercises: z.array(PreviousExerciseDataSchema),
 });
 
@@ -44,6 +45,7 @@ export const RecentWorkoutSummarySchema = z.object({
   name: z.string(),
   completedAt: z.coerce.date(),
   startedAt: z.coerce.date(),
+  bodyWeightLb: z.number().positive().nullable().optional(),
   exerciseSummaries: z.array(z.string()),
 });
 

--- a/prisma/migrations/20260619170000_workout_body_weight/migration.sql
+++ b/prisma/migrations/20260619170000_workout_body_weight/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Workout" ADD COLUMN "bodyWeightLb" REAL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,7 @@ model Workout {
   name             String
   startedAt        DateTime          @default(now())
   completedAt      DateTime?
+  bodyWeightLb     Float?
   notes            String?
   createdAt        DateTime          @default(now())
   updatedAt        DateTime          @updatedAt


### PR DESCRIPTION
## Summary

- Adds the exercise history stats slide with tiny charts for estimated 1RM and working-set volume, using hidden date-scaled x-values so points reflect time gaps.
- Adds workout-level approximate body weight storage and editing, defaulted from the latest saved workout value.
- Uses saved workout body weight when calculating bodyweight history stats, including `BW`, `BW+...`, and `BW-...` sets.
- Adds a development-only `/workout-reference` body-weight sample so the compact editor can be checked without auth.

## Validation

- `npm run typecheck -w @lift-prog/web`
- `npm run test -w @lift-prog/web -- workout.integration.test.tsx previousWorkoutExercise.test.tsx`
- `SKIP_ENV_VALIDATION=1 npm run build -w @lift-prog/web`
- Browser smoke on `http://127.0.0.1:3011/workout-reference`: opened body-weight editor and set `173lb`.

## Notes

- Rebased on latest `main` after PR #14.
- Includes SQLite/Turso migration SQL: `ALTER TABLE "Workout" ADD COLUMN "bodyWeightLb" REAL;`