### PR TITLE
Harden workout draft restore

### DIFF
--- a/apps/web/src/components/workout/use_workout_persistence.ts
+++ b/apps/web/src/components/workout/use_workout_persistence.ts
@@ -4,7 +4,11 @@ import { useCallback, useEffect } from "react";
 import { toast } from "sonner";
 import {
   LOCAL_STORAGE_WORKOUT_KEY,
+  parsePlateLoadMode,
   type Workout,
+  type WorkoutExercise,
+  type WorkoutSet,
+  type SetRestType,
 } from "@lift-prog/workout-core";
 
 export function useWorkoutPersistence({
@@ -84,9 +88,176 @@ function safelyParseWorkoutState(jsonString: string | null): Workout | null {
         typeof (obj as Record<string, unknown>).inputValue === "string"
       );
     }
-    if (isWorkout(parsed)) return parsed;
+    if (isWorkout(parsed)) return normalizeWorkoutState(parsed);
     return null;
   } catch {
     return null;
   }
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+function normalizeWorkoutState(workout: Workout): Workout {
+  const exercises = workout.exercises.map(normalizeWorkoutExercise);
+  return {
+    currentExerciseIndex: clampIndex(workout.currentExerciseIndex, exercises),
+    exercises,
+    activeField: { exerciseIndex: null, setIndex: null, field: null },
+    inputValue: "",
+    isFirstInteraction: false,
+    notes: normalizeNotes(workout.notes),
+    startTime: finiteNumber(workout.startTime) ?? Date.now(),
+    name: stringValue(workout.name) ?? "Workout",
+    isInProgress:
+      typeof workout.isInProgress === "boolean" ? workout.isInProgress : true,
+  };
+}
+
+function normalizeWorkoutExercise(
+  exercise: Workout["exercises"][number],
+  exerciseIndex: number,
+): WorkoutExercise {
+  const record = exercise as unknown as UnknownRecord;
+  const sets = Array.isArray(record.sets)
+    ? record.sets.map((set, setIndex) => normalizeWorkoutSet(set, setIndex))
+    : [];
+  const previousSets = Array.isArray(record.previousSets)
+    ? record.previousSets.map(normalizePreviousSet)
+    : [];
+  const history = Array.isArray(record.history)
+    ? record.history.map(normalizeHistoryEntry)
+    : undefined;
+  const userExerciseId = finiteNumber(record.userExerciseId);
+
+  return {
+    ...(userExerciseId == null ? {} : { userExerciseId }),
+    name: stringValue(record.name) ?? `Exercise ${exerciseIndex + 1}`,
+    exerciseNotes: stringOrNull(record.exerciseNotes),
+    plateStartingWeight: finiteNumber(record.plateStartingWeight),
+    plateLoadMode:
+      typeof record.plateLoadMode === "string"
+        ? parsePlateLoadMode(record.plateLoadMode)
+        : null,
+    sets,
+    previousSets,
+    ...(history ? { history } : {}),
+    ...(stringValue(record.previousSummary)
+      ? { previousSummary: stringValue(record.previousSummary) }
+      : {}),
+    ...(stringValue(record.previousNotes)
+      ? { previousNotes: stringValue(record.previousNotes) }
+      : {}),
+    notes: normalizeNotes(record.notes),
+  };
+}
+
+function normalizeWorkoutSet(value: unknown, index: number): WorkoutSet {
+  const record = asRecord(value);
+  const weight = finiteNumber(record.weight);
+  const reps = finiteNumber(record.reps);
+  const clientId = stringValue(record.clientId) ?? stringValue(record.id);
+  const notes = stringValue(record.notes);
+  const rir = finiteNumber(record.rir);
+  const restBefore = normalizeRestBefore(record.restBefore);
+
+  return {
+    ...(clientId ? { clientId } : { clientId: `restored-set-${index}` }),
+    weight,
+    reps,
+    completed:
+      typeof record.completed === "boolean"
+        ? record.completed
+        : weight !== null && reps !== null,
+    weightExplicit:
+      typeof record.weightExplicit === "boolean"
+        ? record.weightExplicit
+        : weight !== null,
+    repsExplicit:
+      typeof record.repsExplicit === "boolean"
+        ? record.repsExplicit
+        : reps !== null,
+    prevWeight: finiteNumber(record.prevWeight),
+    prevReps: finiteNumber(record.prevReps),
+    ...(record.modifier === "warmup" ? { modifier: "warmup" as const } : {}),
+    ...(record.weightModifier === "bodyweight"
+      ? { weightModifier: "bodyweight" as const }
+      : {}),
+    ...(restBefore ? { restBefore } : {}),
+    ...(notes ? { notes } : {}),
+    ...(rir == null ? {} : { rir }),
+  };
+}
+
+function normalizePreviousSet(value: unknown) {
+  const record = asRecord(value);
+  const notes = stringOrNull(record.notes);
+  const rir = finiteNumber(record.rir);
+  const restBefore = normalizeRestBefore(record.restBefore);
+
+  return {
+    weight: finiteNumber(record.weight),
+    reps: finiteNumber(record.reps),
+    ...(record.modifier === "warmup" ? { modifier: "warmup" as const } : {}),
+    ...(record.weightModifier === "bodyweight"
+      ? { weightModifier: "bodyweight" as const }
+      : {}),
+    ...(restBefore ? { restBefore } : {}),
+    ...(notes == null ? {} : { notes }),
+    ...(rir == null ? {} : { rir }),
+  };
+}
+
+function normalizeHistoryEntry(
+  value: unknown,
+): NonNullable<WorkoutExercise["history"]>[number] {
+  const record = asRecord(value);
+  const rawSets = Array.isArray(record.sets) ? record.sets : [];
+
+  return {
+    relation: stringValue(record.relation) ?? "",
+    relativeDate: stringValue(record.relativeDate) ?? "",
+    date: stringValue(record.date) ?? "",
+    workoutNote: stringOrNull(record.workoutNote),
+    workoutExerciseNote: stringOrNull(record.workoutExerciseNote),
+    exerciseNotesSnapshot: stringOrNull(record.exerciseNotesSnapshot),
+    sets: rawSets.map(normalizePreviousSet),
+  };
+}
+
+function normalizeNotes(value: unknown) {
+  if (!Array.isArray(value)) return [];
+
+  return value.flatMap((note) => {
+    const record = asRecord(note);
+    const text = stringValue(record.text);
+    return text ? [{ text }] : [];
+  });
+}
+
+function asRecord(value: unknown): UnknownRecord {
+  return typeof value === "object" && value !== null
+    ? (value as UnknownRecord)
+    : {};
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function stringOrNull(value: unknown): string | null {
+  return stringValue(value) ?? null;
+}
+
+function normalizeRestBefore(value: unknown): SetRestType | undefined {
+  return value === "short" || value === "standard" ? value : undefined;
+}
+
+function clampIndex<T>(index: number, items: T[]) {
+  if (items.length === 0) return 0;
+  if (!Number.isFinite(index)) return 0;
+  return Math.min(Math.max(0, index), items.length - 1);
 }

--- a/apps/web/src/components/workout/workout_reference_adapters.ts
+++ b/apps/web/src/components/workout/workout_reference_adapters.ts
@@ -17,8 +17,14 @@ export function workoutSetToCurrentSet(
 ): CurrentExerciseSet {
   const id = set.clientId ?? `exercise-${exerciseIndex}-set-${setIndex}`;
   const previousSet = exercise.previousSets[setIndex];
-  const displayWeight = set.weight ?? set.prevWeight ?? previousSet?.weight;
-  const displayReps = set.reps ?? set.prevReps ?? previousSet?.reps;
+  const displayWeight =
+    finiteNumber(set.weight) ??
+    finiteNumber(set.prevWeight) ??
+    finiteNumber(previousSet?.weight);
+  const displayReps =
+    finiteNumber(set.reps) ??
+    finiteNumber(set.prevReps) ??
+    finiteNumber(previousSet?.reps);
   const displayNote = set.notes ?? previousSet?.notes;
   const displayRestBefore = set.restBefore ?? previousSet?.restBefore;
   const rawWeight = displayWeight ?? 0;
@@ -44,13 +50,12 @@ export function workoutSetToCurrentSet(
 }
 
 export function currentSetToWorkoutSet(set: CurrentExerciseSet): WorkoutSet {
-  const parsedWeight =
-    set.weightAmount.trim() === "" ? null : Number(set.weightAmount);
+  const parsedWeight = parseFiniteTextNumber(set.weightAmount);
   const signedWeight =
     parsedWeight == null ? null : set.weightSign * parsedWeight;
   const weight =
     set.weightMode === "bodyweight" ? (signedWeight ?? 0) : parsedWeight;
-  const reps = set.reps.trim() === "" ? null : Number(set.reps);
+  const reps = parseFiniteTextNumber(set.reps);
 
   return {
     clientId: set.id,
@@ -70,6 +75,16 @@ export function currentSetToWorkoutSet(set: CurrentExerciseSet): WorkoutSet {
       : {}),
     ...(set.note?.trim() ? { notes: set.note.trim() } : {}),
   };
+}
+
+function finiteNumber(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function parseFiniteTextNumber(value: string) {
+  if (value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 export function normalizeCurrentSetOrder(sets: CurrentExerciseSet[]) {


### PR DESCRIPTION
## Summary
- Normalize locally restored workout drafts before using them in the workout editor
- Guard set conversion against non-finite weight/reps values so malformed local drafts cannot crash the keyboard

## Verification
- npm run typecheck -w @lift-prog/web
- npm run lint -w @lift-prog/web -- --max-warnings=0
- Verified locally that clicking a workout weight value opens the set keyboard without browser errors