### PR TITLE
Add structured client error reporting

### DIFF
--- a/apps/web/src/app/api/error-reports/route.ts
+++ b/apps/web/src/app/api/error-reports/route.ts
@@ -1,3 +1,5 @@
+import { auth } from "@clerk/nextjs/server";
+
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
@@ -36,8 +38,14 @@ type ErrorReportPayload = {
   timestamp?: string;
 };
 
+type AuthContext = {
+  userId?: string;
+  authError?: string;
+};
+
 export async function POST(request: Request) {
   const receivedAt = new Date().toISOString();
+  const authContext = await getAuthContext();
   let payload: unknown;
 
   try {
@@ -48,7 +56,7 @@ export async function POST(request: Request) {
         level: "error",
         event: "client_error_report_invalid_json",
         receivedAt,
-        server: getServerContext(request),
+        server: getServerContext(request, authContext),
         error: serializeUnknownError(error),
       }),
     );
@@ -64,7 +72,7 @@ export async function POST(request: Request) {
       event: "client_error_boundary",
       receivedAt,
       report,
-      server: getServerContext(request),
+      server: getServerContext(request, authContext),
     }),
   );
 
@@ -106,13 +114,36 @@ function sanitizePayload(payload: unknown): ErrorReportPayload {
   };
 }
 
-function getServerContext(request: Request) {
+async function getAuthContext(): Promise<AuthContext> {
+  const localDevUserId =
+    process.env.NODE_ENV === "development" &&
+    !process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+      ? (process.env.LOCAL_DEV_USER_ID ?? null)
+      : null;
+
+  if (localDevUserId) {
+    return { userId: localDevUserId };
+  }
+
+  try {
+    const authData = await auth();
+    return { userId: authData.userId ?? undefined };
+  } catch (error) {
+    return {
+      authError: serializeUnknownError(error).message,
+    };
+  }
+}
+
+function getServerContext(request: Request, authContext: AuthContext) {
   return {
     vercelEnv: process.env.VERCEL_ENV,
     vercelUrl: process.env.VERCEL_URL,
     commitSha: process.env.VERCEL_GIT_COMMIT_SHA,
     requestId: request.headers.get("x-vercel-id") ?? undefined,
     referer: limitString(request.headers.get("referer"), 2_000),
+    userId: authContext.userId,
+    authError: authContext.authError,
   };
 }
 

--- a/apps/web/src/app/api/error-reports/route.ts
+++ b/apps/web/src/app/api/error-reports/route.ts
@@ -1,0 +1,147 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const STRING_LIMITS = {
+  reportId: 120,
+  scope: 120,
+  name: 160,
+  message: 1_000,
+  stack: 8_000,
+  digest: 240,
+  componentStack: 8_000,
+  url: 2_000,
+  pathname: 1_000,
+  userAgent: 600,
+  language: 80,
+  timestamp: 80,
+} as const;
+
+type ErrorReportPayload = {
+  reportId?: string;
+  scope?: string;
+  name?: string;
+  message?: string;
+  stack?: string;
+  digest?: string;
+  componentStack?: string;
+  url?: string;
+  pathname?: string;
+  userAgent?: string;
+  language?: string;
+  viewport?: {
+    width?: number;
+    height?: number;
+    devicePixelRatio?: number;
+  };
+  timestamp?: string;
+};
+
+export async function POST(request: Request) {
+  const receivedAt = new Date().toISOString();
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "client_error_report_invalid_json",
+        receivedAt,
+        server: getServerContext(request),
+        error: serializeUnknownError(error),
+      }),
+    );
+
+    return new Response(null, { status: 204 });
+  }
+
+  const report = sanitizePayload(payload);
+
+  console.error(
+    JSON.stringify({
+      level: "error",
+      event: "client_error_boundary",
+      receivedAt,
+      report,
+      server: getServerContext(request),
+    }),
+  );
+
+  return new Response(null, { status: 204 });
+}
+
+function sanitizePayload(payload: unknown): ErrorReportPayload {
+  if (!isRecord(payload)) {
+    return {
+      message: "Client sent a non-object error report payload.",
+    };
+  }
+
+  const viewport = isRecord(payload.viewport)
+    ? {
+        width: finiteNumber(payload.viewport.width),
+        height: finiteNumber(payload.viewport.height),
+        devicePixelRatio: finiteNumber(payload.viewport.devicePixelRatio),
+      }
+    : undefined;
+
+  return {
+    reportId: limitString(payload.reportId, STRING_LIMITS.reportId),
+    scope: limitString(payload.scope, STRING_LIMITS.scope),
+    name: limitString(payload.name, STRING_LIMITS.name),
+    message: limitString(payload.message, STRING_LIMITS.message),
+    stack: limitString(payload.stack, STRING_LIMITS.stack),
+    digest: limitString(payload.digest, STRING_LIMITS.digest),
+    componentStack: limitString(
+      payload.componentStack,
+      STRING_LIMITS.componentStack,
+    ),
+    url: limitString(payload.url, STRING_LIMITS.url),
+    pathname: limitString(payload.pathname, STRING_LIMITS.pathname),
+    userAgent: limitString(payload.userAgent, STRING_LIMITS.userAgent),
+    language: limitString(payload.language, STRING_LIMITS.language),
+    viewport,
+    timestamp: limitString(payload.timestamp, STRING_LIMITS.timestamp),
+  };
+}
+
+function getServerContext(request: Request) {
+  return {
+    vercelEnv: process.env.VERCEL_ENV,
+    vercelUrl: process.env.VERCEL_URL,
+    commitSha: process.env.VERCEL_GIT_COMMIT_SHA,
+    requestId: request.headers.get("x-vercel-id") ?? undefined,
+    referer: limitString(request.headers.get("referer"), 2_000),
+  };
+}
+
+function serializeUnknownError(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: limitString(error.stack, 4_000),
+    };
+  }
+
+  return {
+    message: limitString(String(error), 1_000),
+  };
+}
+
+function limitString(value: unknown, limit: number) {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  return value.length > limit ? `${value.slice(0, limit)}...` : value;
+}
+
+function finiteNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { ErrorFallbackContent } from "@/components/error-boundary/app_error_boundary";
+
+export default function AppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorFallbackContent error={error} reset={reset} scope="app" />
+  );
+}

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import "@/styles/globals.css";
+
+import { ErrorFallbackContent } from "@/components/error-boundary/app_error_boundary";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="en">
+      <body className="bg-background font-sans antialiased">
+        <ErrorFallbackContent
+          error={error}
+          reset={reset}
+          scope="global"
+          title="app crashed"
+        />
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/app/workout/error.tsx
+++ b/apps/web/src/app/workout/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { ErrorFallbackContent } from "@/components/error-boundary/app_error_boundary";
+
+export default function WorkoutError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorFallbackContent
+      error={error}
+      reset={reset}
+      scope="workout"
+      title="workout crashed"
+    />
+  );
+}

--- a/apps/web/src/app/workout/layout.tsx
+++ b/apps/web/src/app/workout/layout.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { ClientErrorBoundary } from "@/components/error-boundary/app_error_boundary";
+
+export default function WorkoutLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <ClientErrorBoundary scope="workout" title="workout crashed">
+      {children}
+    </ClientErrorBoundary>
+  );
+}

--- a/apps/web/src/components/error-boundary/app_error_boundary.tsx
+++ b/apps/web/src/components/error-boundary/app_error_boundary.tsx
@@ -16,33 +16,59 @@ type ErrorFallbackContentProps = {
   error: ErrorWithDigest;
   scope: string;
   reset?: () => void;
-  reportId?: string | null;
   componentStack?: string;
   title?: string;
   className?: string;
-  reportOnMount?: boolean;
 };
 
 export function ErrorFallbackContent({
   error,
   scope,
   reset,
-  reportId: initialReportId,
   componentStack,
   title = "something broke",
   className,
-  reportOnMount = true,
 }: ErrorFallbackContentProps) {
-  const [reportId, setReportId] = React.useState(initialReportId ?? null);
+  const reportId = useClientErrorReport({ error, scope, componentStack });
+
+  return (
+    <ErrorFallbackView
+      error={error}
+      reset={reset}
+      reportId={reportId}
+      title={title}
+      className={className}
+    />
+  );
+}
+
+function useClientErrorReport({
+  error,
+  scope,
+  componentStack,
+}: ClientErrorReportInput) {
+  const [reportId, setReportId] = React.useState<string | null>(null);
 
   React.useEffect(() => {
-    if (initialReportId || !reportOnMount) {
-      return;
-    }
-
     setReportId(reportClientError({ error, scope, componentStack }));
-  }, [componentStack, error, initialReportId, reportOnMount, scope]);
+  }, [componentStack, error, scope]);
 
+  return reportId;
+}
+
+function ErrorFallbackView({
+  error,
+  reset,
+  reportId,
+  title,
+  className,
+}: {
+  error: ErrorWithDigest;
+  reset?: () => void;
+  reportId?: string | null;
+  title: string;
+  className?: string;
+}) {
   return (
     <div
       className={cn(
@@ -138,13 +164,10 @@ export class ClientErrorBoundary extends React.Component<
   render() {
     if (this.state.error) {
       return (
-        <ErrorFallbackContent
+        <ErrorFallbackView
           error={this.state.error}
-          scope={this.props.scope}
-          componentStack={this.state.componentStack}
           reportId={this.state.reportId}
-          title={this.props.title}
-          reportOnMount={false}
+          title={this.props.title ?? "something broke"}
           reset={() => {
             this.setState({
               error: null,

--- a/apps/web/src/components/error-boundary/app_error_boundary.tsx
+++ b/apps/web/src/components/error-boundary/app_error_boundary.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import * as React from "react";
+import { Home, RotateCcw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  reportClientError,
+  type ClientErrorReportInput,
+} from "@/lib/client-error-reporting";
+import { cn } from "@/lib/utils";
+
+type ErrorWithDigest = Error & { digest?: string };
+
+type ErrorFallbackContentProps = {
+  error: ErrorWithDigest;
+  scope: string;
+  reset?: () => void;
+  reportId?: string | null;
+  componentStack?: string;
+  title?: string;
+  className?: string;
+  reportOnMount?: boolean;
+};
+
+export function ErrorFallbackContent({
+  error,
+  scope,
+  reset,
+  reportId: initialReportId,
+  componentStack,
+  title = "something broke",
+  className,
+  reportOnMount = true,
+}: ErrorFallbackContentProps) {
+  const [reportId, setReportId] = React.useState(initialReportId ?? null);
+
+  React.useEffect(() => {
+    if (initialReportId || !reportOnMount) {
+      return;
+    }
+
+    setReportId(reportClientError({ error, scope, componentStack }));
+  }, [componentStack, error, initialReportId, reportOnMount, scope]);
+
+  return (
+    <div
+      className={cn(
+        "mx-auto flex min-h-[60vh] w-full max-w-md flex-col justify-center p-4 font-mono",
+        className,
+      )}
+    >
+      <div className="space-y-3">
+        <div>
+          <p className="text-3xl font-bold tracking-normal text-[#1f1b16]">
+            {title}
+          </p>
+          <p className="mt-1 text-sm text-[#7d7668]">
+            error reported
+            {reportId ? ` · ${reportId.slice(0, 8)}` : null}
+          </p>
+        </div>
+
+        <div className="space-y-1 text-sm text-[#3e392f]">
+          <p className="rounded-md bg-[#eee8dd] px-2 py-1">
+            {error.message || "Unknown error"}
+          </p>
+          {error.digest ? (
+            <p className="text-xs text-[#7d7668]">digest · {error.digest}</p>
+          ) : null}
+        </div>
+
+        <div className="flex gap-2 pt-1">
+          {reset ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-8 border-[#d8cdb9] bg-transparent px-2 font-mono"
+              onClick={reset}
+            >
+              <RotateCcw className="size-4" />
+              try again
+            </Button>
+          ) : null}
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 border-[#d8cdb9] bg-transparent px-2 font-mono"
+            onClick={() => {
+              window.location.assign("/");
+            }}
+          >
+            <Home className="size-4" />
+            home
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type ClientErrorBoundaryProps = {
+  children: React.ReactNode;
+  scope: ClientErrorReportInput["scope"];
+  title?: string;
+};
+
+type ClientErrorBoundaryState = {
+  error: ErrorWithDigest | null;
+  componentStack?: string;
+  reportId?: string;
+};
+
+export class ClientErrorBoundary extends React.Component<
+  ClientErrorBoundaryProps,
+  ClientErrorBoundaryState
+> {
+  state: ClientErrorBoundaryState = {
+    error: null,
+  };
+
+  static getDerivedStateFromError(error: ErrorWithDigest) {
+    return { error };
+  }
+
+  componentDidCatch(error: ErrorWithDigest, info: React.ErrorInfo) {
+    const componentStack = info.componentStack ?? undefined;
+    const reportId = reportClientError({
+      error,
+      scope: this.props.scope,
+      componentStack,
+    });
+
+    this.setState({ componentStack, reportId });
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <ErrorFallbackContent
+          error={this.state.error}
+          scope={this.props.scope}
+          componentStack={this.state.componentStack}
+          reportId={this.state.reportId}
+          title={this.props.title}
+          reportOnMount={false}
+          reset={() => {
+            this.setState({
+              error: null,
+              componentStack: undefined,
+              reportId: undefined,
+            });
+          }}
+        />
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/web/src/lib/client-error-reporting.ts
+++ b/apps/web/src/lib/client-error-reporting.ts
@@ -1,0 +1,81 @@
+"use client";
+
+export type ClientErrorReportInput = {
+  error: Error & { digest?: string };
+  scope: string;
+  componentStack?: string;
+};
+
+const reportedErrorKeys = new Map<string, string>();
+
+export function reportClientError({
+  error,
+  scope,
+  componentStack,
+}: ClientErrorReportInput) {
+  const key = [
+    scope,
+    error.digest ?? "",
+    error.name,
+    error.message,
+    componentStack ?? "",
+    getLocation(),
+  ].join("|");
+  const existingReportId = reportedErrorKeys.get(key);
+
+  if (existingReportId) {
+    return existingReportId;
+  }
+
+  const reportId = createReportId();
+  reportedErrorKeys.set(key, reportId);
+
+  const payload = {
+    reportId,
+    scope,
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+    digest: error.digest,
+    componentStack,
+    url: getLocation(),
+    pathname: typeof window === "undefined" ? undefined : window.location.pathname,
+    userAgent:
+      typeof navigator === "undefined" ? undefined : navigator.userAgent,
+    language: typeof navigator === "undefined" ? undefined : navigator.language,
+    viewport:
+      typeof window === "undefined"
+        ? undefined
+        : {
+            width: window.innerWidth,
+            height: window.innerHeight,
+            devicePixelRatio: window.devicePixelRatio,
+          },
+    timestamp: new Date().toISOString(),
+  };
+
+  void fetch("/api/error-reports", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+    keepalive: true,
+  }).catch(() => undefined);
+
+  return reportId;
+}
+
+function createReportId() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function getLocation() {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  return window.location.href;
+}

--- a/apps/web/src/lib/client-error-reporting.ts
+++ b/apps/web/src/lib/client-error-reporting.ts
@@ -6,6 +6,19 @@ export type ClientErrorReportInput = {
   componentStack?: string;
 };
 
+const STRING_LIMITS = {
+  name: 160,
+  message: 1_000,
+  stack: 8_000,
+  digest: 240,
+  componentStack: 8_000,
+  url: 2_000,
+  pathname: 1_000,
+  userAgent: 600,
+  language: 80,
+} as const;
+
+const MAX_REPORTED_ERROR_KEYS = 25;
 const reportedErrorKeys = new Map<string, string>();
 
 export function reportClientError({
@@ -17,9 +30,8 @@ export function reportClientError({
     scope,
     error.digest ?? "",
     error.name,
-    error.message,
-    componentStack ?? "",
-    getLocation(),
+    limitString(error.message, 250),
+    getPathname(),
   ].join("|");
   const existingReportId = reportedErrorKeys.get(key);
 
@@ -28,21 +40,29 @@ export function reportClientError({
   }
 
   const reportId = createReportId();
-  reportedErrorKeys.set(key, reportId);
+  rememberReportedError(key, reportId);
 
   const payload = {
     reportId,
     scope,
-    name: error.name,
-    message: error.message,
-    stack: error.stack,
-    digest: error.digest,
-    componentStack,
+    name: limitString(error.name, STRING_LIMITS.name),
+    message: limitString(error.message, STRING_LIMITS.message),
+    stack: limitString(error.stack, STRING_LIMITS.stack),
+    digest: limitString(error.digest, STRING_LIMITS.digest),
+    componentStack: limitString(
+      componentStack,
+      STRING_LIMITS.componentStack,
+    ),
     url: getLocation(),
-    pathname: typeof window === "undefined" ? undefined : window.location.pathname,
+    pathname: getPathname(),
     userAgent:
-      typeof navigator === "undefined" ? undefined : navigator.userAgent,
-    language: typeof navigator === "undefined" ? undefined : navigator.language,
+      typeof navigator === "undefined"
+        ? undefined
+        : limitString(navigator.userAgent, STRING_LIMITS.userAgent),
+    language:
+      typeof navigator === "undefined"
+        ? undefined
+        : limitString(navigator.language, STRING_LIMITS.language),
     viewport:
       typeof window === "undefined"
         ? undefined
@@ -64,6 +84,19 @@ export function reportClientError({
   return reportId;
 }
 
+function rememberReportedError(key: string, reportId: string) {
+  reportedErrorKeys.set(key, reportId);
+
+  if (reportedErrorKeys.size <= MAX_REPORTED_ERROR_KEYS) {
+    return;
+  }
+
+  const oldestKey = reportedErrorKeys.keys().next().value;
+  if (oldestKey) {
+    reportedErrorKeys.delete(oldestKey);
+  }
+}
+
 function createReportId() {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return crypto.randomUUID();
@@ -77,5 +110,21 @@ function getLocation() {
     return undefined;
   }
 
-  return window.location.href;
+  return limitString(window.location.href, STRING_LIMITS.url);
+}
+
+function getPathname() {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  return limitString(window.location.pathname, STRING_LIMITS.pathname);
+}
+
+function limitString(value: string | undefined, limit: number) {
+  if (!value) {
+    return undefined;
+  }
+
+  return value.length > limit ? `${value.slice(0, limit)}...` : value;
 }


### PR DESCRIPTION
## Summary
- add app/global/workout error boundaries with a compact fallback UI
- report client boundary crashes to a server route as structured JSON logs
- wrap the workout route with a nested client boundary without changing workout page behavior
- tighten the reporter after review: bounded client payloads before keepalive fetch, capped duplicate-report cache, pure fallback view, and Clerk/local-dev user context in server logs

## Validation
- npm run lint -w @lift-prog/web -- --max-warnings=0 --file src/components/error-boundary/app_error_boundary.tsx --file src/lib/client-error-reporting.ts --file src/app/api/error-reports/route.ts --file src/app/error.tsx --file src/app/global-error.tsx --file src/app/workout/error.tsx --file src/app/workout/layout.tsx
- filtered typecheck scan showed no errors for the new error-boundary/reporting files
- npm run build -w @lift-prog/web reached compilation, then failed on existing src/app/admin/page.tsx implicit-any typing unrelated to this PR

Note: full local lint/typecheck are blocked by existing generated Prisma/tRPC baseline issues in this temp worktree, so validation is scoped to the new files.